### PR TITLE
ref: unify pcl command args

### DIFF
--- a/crates/pcl/README.md
+++ b/crates/pcl/README.md
@@ -72,7 +72,7 @@ Commands:
   status  Check current authentication status
 
 Options:
-      --base-url <BASE_URL>  Base URL for authentication service [env: AUTH_BASE_URL=] [default: https://dapp.phylax.systems]
+  -u, --auth-url <AUTH_URL>  Base URL for authentication service [env: PCL_AUTH_URL=] [default: https://dapp.phylax.systems]
   -h, --help                 Print help
 ```
 
@@ -100,6 +100,18 @@ Configuration is stored in `~/.pcl/config.toml` and includes:
 - Authentication token
 - Pending assertions for submission
 - Project settings
+
+### Building
+
+Build your assertion contracts:
+
+```bash
+pcl build [OPTIONS]
+
+Options:
+      --root <ROOT>  Root directory of the project
+  -h, --help         Print help
+```
 
 ### Testing
 
@@ -142,8 +154,8 @@ Arguments:
                          Format: <ARG0> <ARG1> <ARG2>
 
 Options:
-  -u, --url <URL>        URL of the assertion-DA server [default: https://demo-21-assertion-da.phylax.systems]
-  -r, --root <ROOT>      Root directory of the project
+  -u, --da-url <DA_URL>  URL of the assertion-DA server [env: PCL_DA_URL=] [default: https://demo-21-assertion-da.phylax.systems]
+      --root <ROOT>      Root directory of the project
   -h, --help             Print help (see a summary with '-h')
 ```
 
@@ -153,7 +165,7 @@ Options:
 pcl submit [OPTIONS]
 
 Options:
-  -u, --dapp-url <DAPP_URL>                 Base URL for the Credible Layer dApp API [default: https://dapp.phylax.systems/api/v1]
+  -u, --api-url <API_URL>                   Base URL for the Credible Layer dApp API [env: PCL_API_URL=] [default: https://dapp.phylax.systems/api/v1]
   -p, --project-name <PROJECT_NAME>         Optional project name to skip interactive selection
   -a, --assertion-keys <ASSERTION_KEYS>     Optional list of assertion name and constructor args to skip interactive selection
                                             Format: assertion_name OR 'assertion_name(constructor_arg0,constructor_arg1)'

--- a/crates/pcl/core/src/assertion_da.rs
+++ b/crates/pcl/core/src/assertion_da.rs
@@ -59,13 +59,13 @@ pub const DEFAULT_DA_URL: &str = default_da_url!();
 pub struct DaStoreArgs {
     /// URL of the assertion-DA server
     #[clap(
-        long,
+        long = "da-url",
         short = 'u',
         env = "PCL_DA_URL",
         value_hint = ValueHint::Url,
         default_value = DEFAULT_DA_URL
     )]
-    pub url: String,
+    pub da_url: String,
 
     /// Build and flatten arguments for the assertion
     #[clap(flatten)]
@@ -135,7 +135,7 @@ impl DaStoreArgs {
             println!("\n\n{}", "Assertion Information".bold().green());
             println!("{}", "===================".green());
             println!("{assertion}");
-            println!("\nSubmitted to assertion DA: {}", self.url);
+            println!("\nSubmitted to assertion DA: {}", self.da_url);
 
             println!("\n{}", "Next Steps:".bold());
             println!("Submit this assertion to a project with:");
@@ -176,8 +176,8 @@ impl DaStoreArgs {
     /// * `Result<DaClient, DaClientError>` - The configured client or error
     fn create_da_client(&self, config: &CliConfig) -> Result<DaClient, DaClientError> {
         match &config.auth {
-            Some(auth) => DaClient::new_with_auth(&self.url, &auth.access_token),
-            None => DaClient::new(&self.url),
+            Some(auth) => DaClient::new_with_auth(&self.da_url, &auth.access_token),
+            None => DaClient::new(&self.da_url),
         }
     }
 
@@ -412,7 +412,7 @@ mod tests {
 
         let mut config = create_test_config();
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec![Address::random().to_string()],
         };
@@ -444,7 +444,7 @@ mod tests {
 
         let mut config = create_test_config();
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec![Address::random().to_string()],
         };
@@ -490,7 +490,7 @@ mod tests {
 
         let mut config = create_test_config();
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec!["invalid_arg".to_string()],
         };
@@ -518,7 +518,7 @@ mod tests {
     #[tokio::test]
     async fn test_display_success_info() {
         let args = DaStoreArgs {
-            url: "https://demo-21-assertion-da.phylax.systems".to_string(),
+            da_url: "https://demo-21-assertion-da.phylax.systems".to_string(),
             args: create_test_build_args(),
             constructor_args: vec!["arg1".to_string(), "arg2".to_string()],
         };
@@ -558,7 +558,7 @@ mod tests {
         let args = create_test_build_args();
 
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args,
             constructor_args: vec![Address::random().to_string()],
         };
@@ -590,7 +590,7 @@ mod tests {
 
         let mut config = create_test_config();
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec![Address::random().to_string()],
         };
@@ -612,7 +612,7 @@ mod tests {
         let mut config = create_test_config();
         config.auth = None; // Simulate no auth
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec![Address::random().to_string()],
         };
@@ -631,7 +631,7 @@ mod tests {
 
         let mut config = create_test_config();
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec![Address::random().to_string()],
         };
@@ -653,7 +653,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_da_client_with_auth() {
         let args = DaStoreArgs {
-            url: "https://demo-21-assertion-da.phylax.systems".to_string(),
+            da_url: "https://demo-21-assertion-da.phylax.systems".to_string(),
             args: BuildAndFlattenArgs::default(),
             constructor_args: vec!["arg1".to_string(), "arg2".to_string()],
         };
@@ -675,7 +675,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_da_client_without_auth() {
         let args = DaStoreArgs {
-            url: "https://demo-21-assertion-da.phylax.systems".to_string(),
+            da_url: "https://demo-21-assertion-da.phylax.systems".to_string(),
             args: BuildAndFlattenArgs::default(),
             constructor_args: vec!["arg1".to_string(), "arg2".to_string()],
         };
@@ -688,7 +688,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_config() {
         let args = DaStoreArgs {
-            url: "https://demo-21-assertion-da.phylax.systems".to_string(),
+            da_url: "https://demo-21-assertion-da.phylax.systems".to_string(),
             args: BuildAndFlattenArgs {
                 assertion_contract: "test_assertion".to_string(),
                 ..BuildAndFlattenArgs::default()
@@ -717,7 +717,7 @@ mod tests {
         let mock = server.mock("POST", "/").with_status(401).create();
 
         let args = DaStoreArgs {
-            url: server.url(),
+            da_url: server.url(),
             args: create_test_build_args(),
             constructor_args: vec![Address::random().to_string()],
         };
@@ -742,7 +742,7 @@ mod tests {
     #[tokio::test]
     async fn test_run_with_invalid_url() {
         let args = DaStoreArgs {
-            url: "invalid-url".to_string(),
+            da_url: "invalid-url".to_string(),
             args: BuildAndFlattenArgs::default(),
             constructor_args: vec!["arg1".to_string(), "arg2".to_string()],
         };

--- a/crates/pcl/core/src/assertion_submission.rs
+++ b/crates/pcl/core/src/assertion_submission.rs
@@ -43,12 +43,13 @@ pub struct DappSubmitArgs {
     /// Base URL for the Credible Layer dApp API
     #[clap(
         short = 'u',
-        long,
+        long = "api-url",
+        env = "PCL_API_URL",
         value_hint = ValueHint::Url,
         value_name = "API Endpoint",
         default_value = "https://dapp.phylax.systems/api/v1"
     )]
-    pub dapp_url: String,
+    pub api_url: String,
 
     /// Optional project name to skip interactive selection
     #[clap(
@@ -182,7 +183,7 @@ impl DappSubmitArgs {
         let response = client
             .post(format!(
                 "{}/projects/{}/submitted-assertions",
-                self.dapp_url, project.project_id
+                self.api_url, project.project_id
             ))
             .header(
                 "Authorization",
@@ -272,7 +273,7 @@ impl DappSubmitArgs {
         let projects: Vec<Project> = client
             .get(format!(
                 "{}/projects?user={}",
-                self.dapp_url,
+                self.api_url,
                 config
                     .auth
                     .as_ref()
@@ -296,7 +297,7 @@ mod tests {
     #[test]
     fn test_provide_or_select_with_valid_input() {
         let args = DappSubmitArgs {
-            dapp_url: "".to_string(),
+            api_url: "".to_string(),
             project_name: Some("Project1".to_string()),
             assertion_keys: None,
         };
@@ -311,7 +312,7 @@ mod tests {
     #[test]
     fn test_no_stored_assertions() {
         let args = DappSubmitArgs {
-            dapp_url: "".to_string(),
+            api_url: "".to_string(),
             project_name: None,
             assertion_keys: None,
         };
@@ -328,7 +329,7 @@ mod tests {
     #[test]
     fn test_no_projects() {
         let args = DappSubmitArgs {
-            dapp_url: "".to_string(),
+            api_url: "".to_string(),
             project_name: None,
             assertion_keys: None,
         };
@@ -345,7 +346,7 @@ mod tests {
     #[test]
     fn test_select_assertions_with_preselected() {
         let args = DappSubmitArgs {
-            dapp_url: "".to_string(),
+            api_url: "".to_string(),
             project_name: None,
             assertion_keys: Some(vec![AssertionKey::new("assertion1".to_string(), vec![])]),
         };
@@ -369,7 +370,7 @@ mod tests {
     #[test]
     fn test_provide_or_multi_select_with_preselected() {
         let args = DappSubmitArgs {
-            dapp_url: "".to_string(),
+            api_url: "".to_string(),
             project_name: None,
             assertion_keys: Some(vec![AssertionKey::new("assertion1".to_string(), vec![])]),
         };
@@ -388,7 +389,7 @@ mod tests {
     #[test]
     fn test_provide_or_select_with_preselected() {
         let args = DappSubmitArgs {
-            dapp_url: "".to_string(),
+            api_url: "".to_string(),
             project_name: Some("Project1".to_string()),
             assertion_keys: None,
         };

--- a/crates/pcl/core/src/auth.rs
+++ b/crates/pcl/core/src/auth.rs
@@ -84,12 +84,13 @@ pub struct AuthCommand {
     pub command: AuthSubcommands,
 
     #[arg(
-        long = "base-url",
-        env = "AUTH_BASE_URL",
+        short = 'u',
+        long = "auth-url",
+        env = "PCL_AUTH_URL",
         default_value = "https://dapp.phylax.systems",
         help = "Base URL for authentication service"
     )]
-    pub base_url: String,
+    pub auth_url: String,
 }
 
 /// Available authentication subcommands
@@ -151,7 +152,7 @@ impl AuthCommand {
     /// Request an authentication code from the server
     async fn request_auth_code(&self) -> Result<AuthResponse, AuthError> {
         let client = Client::new();
-        let url = format!("{}/api/v1/cli/auth/code", self.base_url);
+        let url = format!("{}/api/v1/cli/auth/code", self.auth_url);
         Ok(client.get(url).send().await?.json().await?)
     }
 
@@ -159,7 +160,7 @@ impl AuthCommand {
     fn display_login_instructions(&self, auth_response: &AuthResponse) {
         let url = format!(
             "{}/device?session_id={}",
-            self.base_url, auth_response.session_id
+            self.auth_url, auth_response.session_id
         );
         println!(
             "\nTo authenticate, please visit:\n\n🔗 {}\n📝 {}\n",
@@ -209,7 +210,7 @@ impl AuthCommand {
         client: &Client,
         auth_response: &AuthResponse,
     ) -> Result<StatusResponse, AuthError> {
-        let url = format!("{}/api/v1/cli/auth/status", self.base_url);
+        let url = format!("{}/api/v1/cli/auth/status", self.auth_url);
         Ok(client
             .get(url)
             .query(&[
@@ -331,7 +332,7 @@ mod tests {
     fn test_display_login_instructions() {
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let auth_response = create_test_auth_response();
 
@@ -344,7 +345,7 @@ mod tests {
         let mut config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let auth_response = create_test_auth_response();
         let status = create_test_status_response();
@@ -376,7 +377,7 @@ mod tests {
         let config = create_test_config();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
 
         // Can't easily test stdout, but we can verify it doesn't panic
@@ -394,7 +395,7 @@ mod tests {
             .with_body(r#"{"code":"123456","sessionId":"test_session","deviceSecret":"test_secret","expiresAt":"2024-12-31"}"#)
             .create();
 
-        let cmd = AuthCommand::try_parse_from(vec!["auth", "--base-url", &server.url(), "login"])
+        let cmd = AuthCommand::try_parse_from(vec!["auth", "--auth-url", &server.url(), "login"])
             .unwrap();
 
         let result = cmd.request_auth_code().await;
@@ -421,7 +422,7 @@ mod tests {
             .with_body(r#"{"verified":true,"address":"0xtest","token":"test_token","refresh_token":"test_refresh"}"#)
             .create();
 
-        let cmd = AuthCommand::try_parse_from(vec!["auth", "--base-url", &server.url(), "login"])
+        let cmd = AuthCommand::try_parse_from(vec!["auth", "--auth-url", &server.url(), "login"])
             .unwrap();
 
         let client = Client::new();
@@ -441,7 +442,7 @@ mod tests {
         let mut config = create_test_config();
         let cmd = AuthCommand::try_parse_from(vec![
             "auth",
-            "--base-url",
+            "--auth-url",
             "https://dapp.phylax.systems",
             "logout",
         ])
@@ -458,7 +459,7 @@ mod tests {
         let config = create_test_config();
         let cmd = AuthCommand::try_parse_from(vec![
             "auth",
-            "--base-url",
+            "--auth-url",
             "https://dapp.phylax.systems",
             "status",
         ])
@@ -473,7 +474,7 @@ mod tests {
         let config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Status,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
 
         let result = cmd.status(&config);
@@ -486,7 +487,7 @@ mod tests {
         let mut config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let auth_response = create_test_auth_response();
         let mut status = create_test_status_response();
@@ -502,7 +503,7 @@ mod tests {
         let mut config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let mut auth_response = create_test_auth_response();
         auth_response.expires_at = "invalid_timestamp".to_string();
@@ -518,7 +519,7 @@ mod tests {
         let mut config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let auth_response = create_test_auth_response();
         let mut status = create_test_status_response();
@@ -534,7 +535,7 @@ mod tests {
         let mut config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let auth_response = create_test_auth_response();
         let mut status = create_test_status_response();
@@ -550,7 +551,7 @@ mod tests {
         let mut config = CliConfig::default();
         let cmd = AuthCommand {
             command: AuthSubcommands::Login,
-            base_url: "https://dapp.phylax.systems".to_string(),
+            auth_url: "https://dapp.phylax.systems".to_string(),
         };
         let auth_response = create_test_auth_response();
         let mut status = create_test_status_response();
@@ -566,7 +567,7 @@ mod tests {
         let mut config = create_test_config();
         let cmd = AuthCommand::try_parse_from(vec![
             "auth",
-            "--base-url",
+            "--auth-url",
             "https://dapp.phylax.systems",
             "login",
         ])

--- a/crates/pcl/core/tests/da_store_int_tests.rs
+++ b/crates/pcl/core/tests/da_store_int_tests.rs
@@ -135,7 +135,7 @@ mod tests {
         let test_setup = TestSetup::new();
         let mut test_runner = test_setup.build().await.unwrap();
         // Override the DA URL to an invalid one
-        test_runner.da_store_args.url = "not-a-url".to_string();
+        test_runner.da_store_args.da_url = "not-a-url".to_string();
 
         let res = test_runner.run().await;
         assert!(matches!(

--- a/crates/pcl/phoundry/src/build.rs
+++ b/crates/pcl/phoundry/src/build.rs
@@ -18,7 +18,6 @@ use crate::error::PhoundryError;
 pub struct BuildArgs {
     /// Root directory of the project
     #[clap(
-        short = 'r',
         long,
         value_hint = ValueHint::DirPath,
         help = "Root directory of the project"

--- a/crates/pcl/phoundry/src/build_and_flatten.rs
+++ b/crates/pcl/phoundry/src/build_and_flatten.rs
@@ -56,7 +56,6 @@ impl BuildAndFlatOutput {
 pub struct BuildAndFlattenArgs {
     /// Root directory of the project
     #[clap(
-        short = 'r',
         long,
         value_hint = ValueHint::DirPath,
         help = "Root directory of the project"


### PR DESCRIPTION
## Changes

### 1. Root Directory Arguments
**Before:** `-r, --root` in `store` and `build` commands  
**After:** `--root` (long form only)  
**Why:** Avoids conflict with Forge's `-r` flag for RPC URL in test command

### 2. URL Arguments
All URL arguments now use `-u` as the short flag with descriptive long forms:

**`pcl store`**  
Before: `-u, --url` (env: `PCL_DA_URL`)  
After: `-u, --da-url` (env: `PCL_DA_URL`)

**`pcl submit`**  
Before: `-u, --dapp-url` (no env var)  
After: `-u, --api-url` (env: `PCL_API_URL`)

**`pcl auth`**  
Before: `--base-url` (env: `AUTH_BASE_URL`)  
After: `-u, --auth-url` (env: `PCL_AUTH_URL`)

**Why:** Provides consistency with `-u` for all URLs while maintaining clarity through descriptive long flags

### 3. Environment Variables
Standardized all env vars with `PCL_` prefix:
- `AUTH_BASE_URL` → `PCL_AUTH_URL`
- Added `PCL_API_URL` for submit command
- `PCL_DA_URL` unchanged