### PR TITLE
fix: skip dapp-api-client codegen in CI when client.rs exists

### DIFF
--- a/crates/dapp-api-client/README.md
+++ b/crates/dapp-api-client/README.md
@@ -91,12 +91,12 @@ make regenerate-dev
 
 Or manually from the crate directory:
 
-1. **Basic regeneration** (uses cached spec if available):
+1. **Basic regeneration** (uses cached spec.json if it exists):
    ```bash
    cargo build --features regenerate
    ```
 
-2. **Force fetch latest spec** from the API:
+2. **Force fetch latest spec** (always fetches fresh from API):
    ```bash
    FORCE_SPEC_REGENERATE=true cargo build --features regenerate
    ```


### PR DESCRIPTION
### Summary
  - Fixes CI build failures for dapp-api-client by skipping code generation when client.rs already exists
  - Ensures CI uses the committed client.rs file without requiring spec.json or network access

  ### Changes
  - Modified build.rs to check if client.rs exists before attempting generation
  - Removed automatic CI spec fetching from codegen.rs
  - Updated README to clarify regeneration behavior