### PR TITLE
feat: sidecar implement getTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10520,6 +10520,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctor",
+ "dashmap",
  "lazy_static",
  "reqwest",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ assertion-executor = { path = "crates/assertion-executor" }
 
 anyhow = "1.0.86"
 clap = { version = "4.5.11", features = ["derive", "env"] }
+dashmap = "6.1.0"
 futures = "0.3.30"
 reqwest = { version = "0.12.5", features = ["json"] }
 serde = "1.0.204"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
+dashmap = {workspace = true}
 revm = { workspace = true }
 anyhow = {workspace =  true }
 thiserror = { workspace = true }

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -39,7 +39,7 @@
 //! assertion reverts before approving a transaction.
 
 pub mod queue;
-pub(crate) mod state;
+pub(crate) mod result_handler;
 
 use super::engine::queue::{
     TransactionQueueReceiver,

--- a/crates/sidecar/src/engine/queue.rs
+++ b/crates/sidecar/src/engine/queue.rs
@@ -21,10 +21,12 @@
 //! New transaction events are transactions that should be executed and included for the
 //! current `BlockEnv`.
 
+use crate::engine::TransactionResult;
 use crossbeam::channel::{
     Receiver,
     Sender,
 };
+use revm::primitives::alloy_primitives::TxHash;
 use revm::{
     context::{
         BlockEnv,
@@ -32,6 +34,7 @@ use revm::{
     },
     primitives::B256,
 };
+use tokio::sync::oneshot;
 
 /// Represents a transaction to be processed by the sidecar engine.
 ///
@@ -54,10 +57,17 @@ pub struct QueueTransaction {
 ///
 /// `Tx` should be used to append a new transaction to the current block,
 /// along with its transaction hash for identification and tracing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum TxQueueContents {
     Block(BlockEnv),
     Tx(QueueTransaction),
+    GetTxResult(QueryGetTxResult),
+}
+
+#[derive(Debug)]
+pub struct QueryGetTxResult {
+    pub tx_hash: TxHash,
+    pub sender: oneshot::Sender<TransactionResult>,
 }
 
 /// `crossbeam` sender for the transaction queue. Sends data to tx queue.

--- a/crates/sidecar/src/engine/queue.rs
+++ b/crates/sidecar/src/engine/queue.rs
@@ -61,7 +61,6 @@ pub struct QueueTransaction {
 pub enum TxQueueContents {
     Block(BlockEnv),
     Tx(QueueTransaction),
-    GetTxResult(QueryGetTxResult),
 }
 
 #[derive(Debug)]
@@ -74,3 +73,8 @@ pub struct QueryGetTxResult {
 pub type TransactionQueueSender = Sender<TxQueueContents>;
 /// `crossbeam` receiver for the transaction queue. Receives data from tx queue.
 pub type TransactionQueueReceiver = Receiver<TxQueueContents>;
+
+/// `crossbeam` sender for the get transaction result queue. Sends transaction result query requests.
+pub type GetTransactionResultQueueSender = Sender<QueryGetTxResult>;
+/// `crossbeam` receiver for the get transaction result queue. Receives transaction result query responses.
+pub type GetTransactionResultQueueReceiver = Receiver<QueryGetTxResult>;

--- a/crates/sidecar/src/engine/result_handler.rs
+++ b/crates/sidecar/src/engine/result_handler.rs
@@ -9,12 +9,12 @@ use dashmap::mapref::one::Ref;
 use std::sync::Arc;
 use tracing::error;
 
-pub(crate) struct State {
+pub(crate) struct ResultHandler {
     get_tx_result_receiver: GetTransactionResultQueueReceiver,
     state_results: Arc<StateResults>,
 }
 
-impl State {
+impl ResultHandler {
     pub(crate) fn new(
         get_tx_result_receiver: GetTransactionResultQueueReceiver,
         state_results: Arc<StateResults>,
@@ -103,13 +103,13 @@ mod tests {
     use tokio::sync::oneshot;
 
     fn create_test_state() -> (
-        State,
+        ResultHandler,
         crossbeam::channel::Sender<QueryGetTxResult>,
         Arc<StateResults>,
     ) {
         let (sender, receiver) = unbounded();
         let state_results = StateResults::new();
-        let state = State::new(receiver, state_results.clone());
+        let state = ResultHandler::new(receiver, state_results.clone());
         (state, sender, state_results)
     }
 
@@ -141,7 +141,7 @@ mod tests {
         let (sender, receiver) = unbounded();
         let state_results = StateResults::new();
 
-        let state = State::new(receiver, state_results.clone());
+        let state = ResultHandler::new(receiver, state_results.clone());
 
         // Verify state was constructed correctly by testing basic functionality
         let tx_hash = B256::from([0x99; 32]);

--- a/crates/sidecar/src/engine/state.rs
+++ b/crates/sidecar/src/engine/state.rs
@@ -1,0 +1,560 @@
+use crate::engine::queue::GetTransactionResultQueueReceiver;
+use crate::engine::{
+    EngineError,
+    StateResults,
+    TransactionResult,
+};
+use assertion_executor::primitives::B256;
+use dashmap::mapref::one::Ref;
+use std::sync::Arc;
+use tracing::error;
+
+pub(crate) struct State {
+    get_tx_result_receiver: GetTransactionResultQueueReceiver,
+    state_results: Arc<StateResults>,
+}
+
+impl State {
+    pub(crate) fn new(
+        get_tx_result_receiver: GetTransactionResultQueueReceiver,
+        state_results: Arc<StateResults>,
+    ) -> Self {
+        Self {
+            get_tx_result_receiver,
+            state_results,
+        }
+    }
+
+    /// Get transaction result by hash.
+    fn get_transaction_result(&self, tx_hash: &B256) -> Option<Ref<'_, B256, TransactionResult>> {
+        self.state_results.transaction_results.get(tx_hash)
+    }
+
+    pub(crate) async fn run(&mut self) -> Result<(), EngineError> {
+        loop {
+            let event = self.get_tx_result_receiver.try_recv().map_err(|e| {
+                error!(
+                    target = "engine",
+                    error = ?e,
+                    "Get transaction result queue channel closed"
+                );
+                EngineError::GetTxResultChannelClosed
+            })?;
+
+            let tx_hash = event.tx_hash;
+            let result = self.get_transaction_result(&tx_hash);
+            match result {
+                Some(result) => {
+                    event.sender.send(result.clone()).map_err(|e| {
+                        error!(
+                            target = "engine",
+                            error = ?e,
+                            tx_hash = %tx_hash,
+                            "Failed to send transaction result to query sender"
+                        );
+                        EngineError::GetTxResultChannelClosed
+                    })?;
+                }
+                None => {
+                    if let Ok(mut pending_queries) = self.state_results.pending_queries.lock() {
+                        pending_queries.insert(event.tx_hash, event.sender);
+
+                        // Check the race condition in which the engine is faster than this process:
+                        // Then it could happen:
+                        // 1. The engine is processing the requested transaction
+                        // 2. This process checks for the result and doesn't find it
+                        // 3. The engine adds the result to the state
+                        // 4. This process adds the query to pending_queries
+                        // 5. The engine already checked pending_queries just before it was written
+                        let result = self.get_transaction_result(&tx_hash);
+                        if let Some(result) = result
+                            && let Some(sender) = pending_queries.remove(&tx_hash)
+                        {
+                            sender.send(result.clone()).map_err(|e| {
+                                error!(
+                                    target = "engine",
+                                    error = ?e,
+                                    tx_hash = %tx_hash,
+                                    "Failed to send transaction result to query sender"
+                                );
+                                EngineError::GetTxResultChannelClosed
+                            })?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::queue::QueryGetTxResult;
+    use assertion_executor::primitives::ExecutionResult;
+    use assertion_executor::primitives::HaltReason;
+    use crossbeam::channel::unbounded;
+    use revm::context::result::{
+        Output,
+        SuccessReason,
+    };
+    use std::sync::Arc;
+    use tokio::sync::oneshot;
+
+    fn create_test_state() -> (
+        State,
+        crossbeam::channel::Sender<QueryGetTxResult>,
+        Arc<StateResults>,
+    ) {
+        let (sender, receiver) = unbounded();
+        let state_results = StateResults::new();
+        let state = State::new(receiver, state_results.clone());
+        (state, sender, state_results)
+    }
+
+    fn create_sample_transaction_result(is_valid: bool) -> TransactionResult {
+        if is_valid {
+            TransactionResult::ValidationCompleted {
+                execution_result: ExecutionResult::Success {
+                    reason: SuccessReason::Return,
+                    gas_used: 21000,
+                    gas_refunded: 0,
+                    logs: vec![],
+                    output: Output::Call(vec![].into()),
+                },
+                is_valid: true,
+            }
+        } else {
+            TransactionResult::ValidationCompleted {
+                execution_result: ExecutionResult::Halt {
+                    reason: HaltReason::CallNotAllowedInsideStatic,
+                    gas_used: 100000,
+                },
+                is_valid: false,
+            }
+        }
+    }
+
+    #[test]
+    fn test_state_new() {
+        let (sender, receiver) = unbounded();
+        let state_results = StateResults::new();
+
+        let state = State::new(receiver, state_results.clone());
+
+        // Verify state was constructed correctly by testing basic functionality
+        let tx_hash = B256::from([0x99; 32]);
+        let transaction_result = create_sample_transaction_result(true);
+
+        // Insert via the shared state_results
+        state_results
+            .transaction_results
+            .insert(tx_hash, transaction_result.clone());
+
+        // Verify state can access it
+        let result = state.get_transaction_result(&tx_hash);
+        assert!(
+            result.is_some(),
+            "State should have access to shared state_results"
+        );
+        assert_eq!(*result.unwrap(), transaction_result);
+
+        // Clean up
+        drop(sender);
+    }
+
+    #[test]
+    fn test_get_transaction_result_existing() {
+        let (state, _sender, state_results) = create_test_state();
+
+        // Insert a test transaction result
+        let tx_hash = B256::from([0x11; 32]);
+        let transaction_result = create_sample_transaction_result(true);
+
+        state_results
+            .transaction_results
+            .insert(tx_hash, transaction_result.clone());
+
+        // Test getting the result
+        let result = state.get_transaction_result(&tx_hash);
+        assert!(result.is_some(), "Should find existing transaction result");
+        assert_eq!(*result.unwrap(), transaction_result);
+    }
+
+    #[test]
+    fn test_get_transaction_result_nonexistent() {
+        let (state, _sender, _state_results) = create_test_state();
+
+        let tx_hash = B256::from([0x22; 32]);
+        let result = state.get_transaction_result(&tx_hash);
+        assert!(
+            result.is_none(),
+            "Should return None for non-existent transaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_handles_existing_result() {
+        let (mut state, sender, state_results) = create_test_state();
+
+        // Insert a test transaction result first
+        let tx_hash = B256::from([0x33; 32]);
+        let transaction_result = create_sample_transaction_result(true);
+
+        state_results
+            .transaction_results
+            .insert(tx_hash, transaction_result.clone());
+
+        // Create a query for this transaction
+        let (result_sender, result_receiver) = oneshot::channel();
+        let query = QueryGetTxResult {
+            tx_hash,
+            sender: result_sender,
+        };
+
+        // Send the query
+        sender.send(query).unwrap();
+
+        // Run state processing (will process one query and continue the loop)
+        // We need to spawn this in a task and then cancel it since run() has an infinite loop
+        let state_handle = tokio::spawn(async move {
+            let _ = state.run().await;
+        });
+
+        // Give it time to process the query
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Check that we received the result
+        let received_result = result_receiver.await.unwrap();
+        assert_eq!(received_result, transaction_result);
+
+        // Clean up the task
+        state_handle.abort();
+        let _ = state_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_run_handles_pending_query() {
+        let (mut state, sender, state_results) = create_test_state();
+
+        let tx_hash = B256::from([0x44; 32]);
+
+        // Create a query for a transaction that doesn't exist yet
+        let (result_sender, _result_receiver) = oneshot::channel();
+        let query = QueryGetTxResult {
+            tx_hash,
+            sender: result_sender,
+        };
+
+        // Send the query
+        sender.send(query).unwrap();
+
+        // Run state processing in background
+        let state_handle = tokio::spawn(async move {
+            let _ = state.run().await;
+        });
+
+        // Give it time to process and add to pending queries
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Verify the query was added to pending queries
+        {
+            let pending = state_results.pending_queries.lock().unwrap();
+            assert!(
+                pending.contains_key(&tx_hash),
+                "Query should be added to pending queries"
+            );
+        }
+
+        // Clean up
+        state_handle.abort();
+        let _ = state_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_run_channel_closed_error() {
+        let (mut state, sender, _state_results) = create_test_state();
+
+        // Close the sender channel
+        drop(sender);
+
+        // Run should return an error when the channel is closed
+        let result = state.run().await;
+        assert!(
+            result.is_err(),
+            "Should return error when channel is closed"
+        );
+        match result.unwrap_err() {
+            EngineError::GetTxResultChannelClosed => {
+                // Expected error
+            }
+            other => panic!("Expected GetTxResultChannelClosed error, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_send_error_handling() {
+        let (mut state, sender, state_results) = create_test_state();
+
+        // Insert a test transaction result
+        let tx_hash = B256::from([0x55; 32]);
+        let transaction_result = create_sample_transaction_result(true);
+        state_results
+            .transaction_results
+            .insert(tx_hash, transaction_result);
+
+        // Create a query with a receiver that we'll drop to simulate send failure
+        let (result_sender, result_receiver) = oneshot::channel();
+        drop(result_receiver); // Drop receiver to make send fail
+
+        let query = QueryGetTxResult {
+            tx_hash,
+            sender: result_sender,
+        };
+
+        // Send the query
+        sender.send(query).unwrap();
+
+        // Run state processing
+        let state_handle = tokio::spawn(async move {
+            let _ = state.run().await;
+        });
+
+        // Give it time to process the query (it should handle the send error gracefully)
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // Clean up
+        state_handle.abort();
+        let _ = state_handle.await;
+
+        // The test passes if we get here without panicking - error was handled gracefully
+    }
+
+    #[test]
+    fn test_multiple_queries_for_same_transaction() {
+        let (state, _sender, state_results) = create_test_state();
+
+        let tx_hash = B256::from([0x66; 32]);
+
+        // Create multiple pending queries for the same transaction
+        let (sender1, _receiver1) = oneshot::channel();
+        let (sender2, _receiver2) = oneshot::channel();
+
+        // Add them to pending queries manually
+        {
+            let mut pending = state_results.pending_queries.lock().unwrap();
+            pending.insert(tx_hash, sender1);
+            // This will overwrite the first sender - only one query per tx_hash is kept
+            pending.insert(tx_hash, sender2);
+        }
+
+        // Verify only the last sender remains
+        {
+            let pending = state_results.pending_queries.lock().unwrap();
+            assert_eq!(
+                pending.len(),
+                1,
+                "Should only have one pending query per tx_hash"
+            );
+            assert!(pending.contains_key(&tx_hash), "Should contain the tx_hash");
+        }
+
+        // Clean up to avoid dropping the channel receivers in the wrong order
+        drop(state);
+    }
+
+    #[test]
+    fn test_state_results_thread_safety() {
+        let (_state, _sender, state_results) = create_test_state();
+        let tx_hash = B256::from([0x77; 32]);
+
+        // Test that StateResults can be safely shared between threads
+        let state_results_clone = state_results.clone();
+        let handle = std::thread::spawn(move || {
+            let transaction_result = create_sample_transaction_result(true);
+
+            // Insert from another thread
+            state_results_clone
+                .transaction_results
+                .insert(tx_hash, transaction_result);
+        });
+
+        handle.join().unwrap();
+
+        // Verify we can read the result from the original thread
+        let result = state_results.transaction_results.get(&tx_hash);
+        assert!(
+            result.is_some(),
+            "Should be able to read result inserted from another thread"
+        );
+    }
+
+    #[test]
+    fn test_validation_error_result() {
+        let (state, _sender, state_results) = create_test_state();
+
+        let tx_hash = B256::from([0x88; 32]);
+        let error_result = TransactionResult::ValidationError("Test validation error".to_string());
+
+        state_results
+            .transaction_results
+            .insert(tx_hash, error_result.clone());
+
+        let result = state.get_transaction_result(&tx_hash);
+        assert!(result.is_some(), "Should find validation error result");
+        match result.unwrap().clone() {
+            TransactionResult::ValidationError(msg) => {
+                assert_eq!(msg, "Test validation error");
+            }
+            other => panic!("Expected ValidationError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_failed_validation_result() {
+        let (state, _sender, state_results) = create_test_state();
+
+        let tx_hash = B256::from([0x99; 32]);
+        let failed_result = create_sample_transaction_result(false);
+
+        state_results
+            .transaction_results
+            .insert(tx_hash, failed_result.clone());
+
+        let result = state.get_transaction_result(&tx_hash);
+        assert!(result.is_some(), "Should find failed validation result");
+        match result.unwrap().clone() {
+            TransactionResult::ValidationCompleted {
+                is_valid,
+                execution_result,
+            } => {
+                assert!(!is_valid, "Transaction should be marked as invalid");
+                match execution_result {
+                    ExecutionResult::Halt { reason, .. } => {
+                        assert_eq!(reason, HaltReason::CallNotAllowedInsideStatic);
+                    }
+                    other => panic!("Expected Revert result, got {:?}", other),
+                }
+            }
+            other => panic!("Expected ValidationCompleted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_concurrent_access_to_transaction_results() {
+        let (_state, _sender, state_results) = create_test_state();
+
+        // Spawn multiple threads that read and write transaction results
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let state_results_clone = state_results.clone();
+            let handle = std::thread::spawn(move || {
+                let tx_hash = B256::from([i; 32]);
+                let transaction_result = create_sample_transaction_result(i % 2 == 0);
+
+                // Insert result
+                state_results_clone
+                    .transaction_results
+                    .insert(tx_hash, transaction_result.clone());
+
+                // Read it back
+                let result = state_results_clone.transaction_results.get(&tx_hash);
+                assert!(result.is_some(), "Should find result we just inserted");
+                assert_eq!(*result.unwrap(), transaction_result);
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all threads to complete
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // Verify all results are there
+        assert_eq!(
+            state_results.transaction_results.len(),
+            10,
+            "Should have 10 results"
+        );
+    }
+
+    #[test]
+    fn test_dashmap_behavior() {
+        let (_state, _sender, state_results) = create_test_state();
+        let tx_hash = B256::from([0xaa; 32]);
+
+        // Test that DashMap behaves as expected
+        assert!(
+            state_results.transaction_results.is_empty(),
+            "Should start empty"
+        );
+
+        let transaction_result = create_sample_transaction_result(true);
+        state_results
+            .transaction_results
+            .insert(tx_hash, transaction_result.clone());
+
+        assert_eq!(
+            state_results.transaction_results.len(),
+            1,
+            "Should have one entry"
+        );
+        assert!(
+            state_results.transaction_results.contains_key(&tx_hash),
+            "Should contain the key"
+        );
+
+        // Test get vs get_mut behavior
+        let read_result = state_results.transaction_results.get(&tx_hash);
+        assert!(read_result.is_some(), "Should be able to read");
+        assert_eq!(*read_result.unwrap(), transaction_result);
+
+        // Test removal
+        let removed = state_results.transaction_results.remove(&tx_hash);
+        assert!(removed.is_some(), "Should be able to remove");
+        assert_eq!(removed.unwrap().1, transaction_result);
+
+        assert!(
+            state_results.transaction_results.is_empty(),
+            "Should be empty after removal"
+        );
+    }
+
+    #[test]
+    fn test_pending_queries_mutex_behavior() {
+        let (_state, _sender, state_results) = create_test_state();
+        let tx_hash = B256::from([0xbb; 32]);
+
+        // Test that the mutex works correctly
+        {
+            let mut pending = state_results.pending_queries.lock().unwrap();
+            assert!(pending.is_empty(), "Should start empty");
+
+            let (sender, _receiver) = oneshot::channel();
+            pending.insert(tx_hash, sender);
+            assert_eq!(pending.len(), 1, "Should have one pending query");
+        } // Lock is dropped here
+
+        // Test that we can access it again
+        {
+            let pending = state_results.pending_queries.lock().unwrap();
+            assert!(
+                pending.contains_key(&tx_hash),
+                "Should still contain the query"
+            );
+        }
+
+        // Test removal
+        {
+            let mut pending = state_results.pending_queries.lock().unwrap();
+            let removed = pending.remove(&tx_hash);
+            assert!(removed.is_some(), "Should be able to remove");
+        }
+
+        {
+            let pending = state_results.pending_queries.lock().unwrap();
+            assert!(pending.is_empty(), "Should be empty after removal");
+        }
+    }
+}

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -71,7 +71,8 @@ async fn main() -> anyhow::Result<()> {
         assertion_executor,
         engine_state_results.clone(),
     );
-    let mut engine_state = engine::result_handler::ResultHandler::new(get_tx_result_receiver, engine_state_results);
+    let mut engine_state =
+        engine::result_handler::ResultHandler::new(get_tx_result_receiver, engine_state_results);
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
         assertion_executor,
         engine_state_results.clone(),
     );
-    let mut engine_state = engine::state::State::new(get_tx_result_receiver, engine_state_results);
+    let mut engine_state = engine::result_handler::ResultHandler::new(get_tx_result_receiver, engine_state_results);
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -36,6 +36,7 @@ use revm::database::{
 use clap::Parser;
 use rust_tracing::trace;
 
+use crate::engine::StateResults;
 use args::SidecarArgs;
 
 #[tokio::main]
@@ -45,6 +46,7 @@ async fn main() -> anyhow::Result<()> {
     let args = SidecarArgs::parse();
 
     let (tx_sender, tx_receiver) = unbounded();
+    let (get_tx_result_sender, get_tx_result_receiver) = unbounded();
     let state: OverlayDb<CacheDB<EmptyDBTyped<Infallible>>> = OverlayDb::new(
         None,
         args.credible
@@ -59,9 +61,17 @@ async fn main() -> anyhow::Result<()> {
     let indexer_cfg = init_indexer_config(&args, assertion_store, executor_config).await?;
 
     let (_, mock_receiver) = unbounded();
-    let mock_transport = MockTransport::with_receiver(tx_sender, mock_receiver);
+    let mock_transport =
+        MockTransport::with_receiver(tx_sender, mock_receiver, get_tx_result_sender);
 
-    let mut engine = CoreEngine::new(state, tx_receiver, assertion_executor);
+    let engine_state_results = StateResults::new();
+    let mut engine = CoreEngine::new(
+        state,
+        tx_receiver,
+        assertion_executor,
+        engine_state_results.clone(),
+    );
+    let mut engine_state = engine::state::State::new(get_tx_result_receiver, engine_state_results);
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
@@ -72,6 +82,9 @@ async fn main() -> anyhow::Result<()> {
         }
         _ = engine.run() => {
             tracing::info!("Engine run completed, shutting down...");
+        }
+        _ = engine_state.run() => {
+            tracing::info!("Engine state run completed, shutting down...");
         }
         _ = mock_transport.run() => {
             tracing::info!("Engine run completed, shutting down...");

--- a/crates/sidecar/src/transport/README.md
+++ b/crates/sidecar/src/transport/README.md
@@ -176,7 +176,7 @@ Retrieves transaction results by hash. Can retrieve one or many transactions at 
         "hash": "0xefgh5678901234567890...",
         "status": "assertion_failed",
         "gas_used": 18500,
-        "error": "Assertion 0x123... failed: insufficient balance"
+        "error": null
       },
       {
         "hash": "0xijkl9012345678901234...",

--- a/crates/sidecar/src/transport/decoder.rs
+++ b/crates/sidecar/src/transport/decoder.rs
@@ -6,6 +6,10 @@
 //! the core engine.
 
 use crate::engine::queue::TxQueueContents;
+use crate::transport::http::server::{
+    METHOD_BLOCK_ENV,
+    METHOD_SEND_TRANSACTIONS,
+};
 use crate::{
     engine::queue::QueueTransaction,
     transport::http::server::{
@@ -118,10 +122,6 @@ impl TryFrom<&TransactionEnv> for TxEnv {
 pub struct HttpTransactionDecoder;
 
 impl HttpTransactionDecoder {
-    const METHOD_SEND_TRANSACTIONS: &'static str = "sendTransactions";
-    const METHOD_BLOCK_ENV: &'static str = "sendBlockEnv
-";
-
     fn to_transaction(req: &JsonRpcRequest) -> Result<Vec<TxQueueContents>, HttpDecoderError> {
         let params = req.params.as_ref().ok_or(HttpDecoderError::MissingParams)?;
         let send_params: SendTransactionsParams =
@@ -152,8 +152,8 @@ impl Decoder for HttpTransactionDecoder {
 
     fn to_tx_queue_contents(req: &Self::RawEvent) -> Result<Vec<TxQueueContents>, Self::Error> {
         match req.method.as_str() {
-            Self::METHOD_SEND_TRANSACTIONS => Self::to_transaction(req),
-            Self::METHOD_BLOCK_ENV => {
+            METHOD_SEND_TRANSACTIONS => Self::to_transaction(req),
+            METHOD_BLOCK_ENV => {
                 let params = req.params.as_ref().ok_or(HttpDecoderError::MissingParams)?;
                 let block = serde_json::from_value::<BlockEnv>(params.clone())
                     .map_err(|_| HttpDecoderError::SchemaError)?;

--- a/crates/sidecar/src/transport/http/server.rs
+++ b/crates/sidecar/src/transport/http/server.rs
@@ -1,5 +1,10 @@
 //! JSON-RPC server handlers for HTTP transport
 
+use crate::engine::TransactionResult;
+use crate::engine::queue::{
+    QueryGetTxResult,
+    TxQueueContents,
+};
 use crate::{
     engine::queue::TransactionQueueSender,
     transport::decoder::{
@@ -7,6 +12,7 @@ use crate::{
         HttpTransactionDecoder,
     },
 };
+use assertion_executor::primitives::ExecutionResult;
 use axum::{
     extract::{
         Json,
@@ -15,6 +21,7 @@ use axum::{
     http::StatusCode,
     response::Json as ResponseJson,
 };
+use revm::primitives::alloy_primitives::TxHash;
 use serde::{
     Deserialize,
     Serialize,
@@ -26,12 +33,17 @@ use std::sync::{
         Ordering,
     },
 };
+use tokio::sync::oneshot;
 use tracing::{
     debug,
     error,
     instrument,
     trace,
 };
+
+pub(in crate::transport) const METHOD_SEND_TRANSACTIONS: &str = "sendTransactions";
+pub(in crate::transport) const METHOD_BLOCK_ENV: &str = "sendBlockEnv";
+pub(in crate::transport) const METHOD_GET_TRANSACTION: &str = "getTransactions";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TransactionEnv {
@@ -183,14 +195,18 @@ pub async fn handle_transaction_rpc(
 ) -> Result<ResponseJson<JsonRpcResponse>, StatusCode> {
     debug!("Processing JSON-RPC request");
 
-    let response = if request.method != "sendTransactions" {
-        debug!(
-            method = %request.method,
-            "Unknown JSON-RPC method requested"
-        );
-        JsonRpcResponse::method_not_found(&request)
-    } else {
-        handle_send_transactions(&state, &request).await?
+    let response = match request.method.as_str() {
+        METHOD_SEND_TRANSACTIONS | METHOD_BLOCK_ENV => {
+            handle_send_transactions(&state, &request).await?
+        }
+        METHOD_GET_TRANSACTION => handle_get_transactions(&state, &request).await?,
+        _ => {
+            debug!(
+                method = %request.method,
+                "Unknown JSON-RPC method requested"
+            );
+            JsonRpcResponse::method_not_found(&request)
+        }
     };
 
     debug!(
@@ -269,4 +285,161 @@ async fn handle_send_transactions(
             "message": format!("Successfully processed {} transactions", transaction_count)
         }),
     ))
+}
+
+async fn handle_get_transactions(
+    state: &ServerState,
+    request: &JsonRpcRequest,
+) -> Result<JsonRpcResponse, StatusCode> {
+    trace!("Processing getTransactions request");
+
+    // Check if we have block environment before processing transactions
+    if !state.has_blockenv.load(Ordering::Relaxed) {
+        debug!("Rejecting transaction - no block environment available");
+        return Ok(JsonRpcResponse::block_not_available(request));
+    }
+
+    let Some(params) = &request.params else {
+        debug!("getTransactions request missing required parameters");
+        return Ok(JsonRpcResponse::internal_error(
+            request,
+            "Missing params for getTransactions",
+        ));
+    };
+
+    let Ok(tx_hashes) = serde_json::from_value::<Vec<TxHash>>(params.clone()) else {
+        debug!("getTransactions request invalid tx hash format");
+        return Ok(JsonRpcResponse::internal_error(
+            request,
+            "Invalid params for getTransactions",
+        ));
+    };
+
+    // Can you write me here the sending to the queue + waiting for the result?
+    let mut results = Vec::with_capacity(tx_hashes.len());
+
+    // Process each transaction hash
+    for tx_hash in tx_hashes {
+        // Can you write me here the sending to the queue + waiting for the result?
+        let (response_tx, response_rx) = oneshot::channel();
+
+        let query = QueryGetTxResult {
+            tx_hash,
+            sender: response_tx,
+        };
+
+        // Send query to engine
+        if let Err(e) = state.tx_sender.send(TxQueueContents::GetTxResult(query)) {
+            error!(
+                error = %e,
+                tx_hash = %tx_hash,
+                "Failed to send get transaction query to engine"
+            );
+            return Ok(JsonRpcResponse::internal_error(
+                request,
+                "Internal error: failed to queue get transaction result",
+            ));
+        }
+
+        // Wait for response with timeout
+        let transaction_result = match response_rx.await {
+            Ok(result) => result,
+            Err(_) => {
+                error!(
+                    tx_hash = %tx_hash,
+                    "Engine dropped response channel for transaction query"
+                );
+                return Ok(JsonRpcResponse::internal_error(
+                    request,
+                    "Internal error: engine unavailable",
+                ));
+            }
+        };
+
+        // Convert result to JSON format
+        results.push(into_transaction_result_response(
+            tx_hash.to_string(),
+            &transaction_result,
+        ));
+    }
+
+    debug!(
+        result_count = results.len(),
+        "Successfully processed transaction queries"
+    );
+
+    Ok(JsonRpcResponse::success(
+        request,
+        serde_json::json!({
+            "results": results,
+            "not_found": []
+        }),
+    ))
+}
+
+/// Helper function to determine transaction status and error message
+fn into_transaction_result_response(
+    hash: String,
+    result: &TransactionResult,
+) -> TransactionResultResponse {
+    match result {
+        TransactionResult::ValidationCompleted {
+            execution_result,
+            is_valid,
+        } => {
+            let gas_used = Some(execution_result.gas_used());
+            match execution_result {
+                ExecutionResult::Success { .. } => {
+                    TransactionResultResponse {
+                        hash,
+                        status: "success".to_string(),
+                        gas_used,
+                        error: None,
+                    }
+                }
+                ExecutionResult::Revert { .. } => {
+                    TransactionResultResponse {
+                        hash,
+                        status: "failed".to_string(),
+                        gas_used,
+                        error: None,
+                    }
+                }
+                ExecutionResult::Halt { reason, .. } => {
+                    if !*is_valid {
+                        // Transaction failed assertion validation
+                        TransactionResultResponse {
+                            hash,
+                            status: "assertion_failed".to_string(),
+                            gas_used,
+                            error: Some(format!("Assertion failed: {:?}", reason)),
+                        }
+                    } else {
+                        TransactionResultResponse {
+                            hash,
+                            status: "failed".to_string(),
+                            gas_used,
+                            error: Some(format!("Transaction halted: {:?}", reason)),
+                        }
+                    }
+                }
+            }
+        }
+        TransactionResult::ValidationError(error) => {
+            TransactionResultResponse {
+                hash,
+                status: "failed".to_string(),
+                gas_used: None,
+                error: Some(format!("Validation error: {}", error)),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct TransactionResultResponse {
+    pub hash: String,
+    pub status: String,
+    pub gas_used: Option<u64>,
+    pub error: Option<String>,
 }

--- a/crates/sidecar/src/transport/http/server.rs
+++ b/crates/sidecar/src/transport/http/server.rs
@@ -2,8 +2,8 @@
 
 use crate::engine::TransactionResult;
 use crate::engine::queue::{
+    GetTransactionResultQueueSender,
     QueryGetTxResult,
-    TxQueueContents,
 };
 use crate::{
     engine::queue::TransactionQueueSender,
@@ -169,13 +169,19 @@ impl JsonRpcResponse {
 pub struct ServerState {
     pub has_blockenv: Arc<AtomicBool>,
     pub tx_sender: TransactionQueueSender,
+    pub get_tx_result_sender: GetTransactionResultQueueSender,
 }
 
 impl ServerState {
-    pub fn new(has_blockenv: Arc<AtomicBool>, tx_sender: TransactionQueueSender) -> Self {
+    pub fn new(
+        has_blockenv: Arc<AtomicBool>,
+        tx_sender: TransactionQueueSender,
+        get_tx_result_sender: GetTransactionResultQueueSender,
+    ) -> Self {
         Self {
             has_blockenv,
             tx_sender,
+            get_tx_result_sender,
         }
     }
 }
@@ -329,7 +335,7 @@ async fn handle_get_transactions(
         };
 
         // Send query to engine
-        if let Err(e) = state.tx_sender.send(TxQueueContents::GetTxResult(query)) {
+        if let Err(e) = state.get_tx_result_sender.send(query) {
             error!(
                 error = %e,
                 tx_hash = %tx_hash,

--- a/crates/sidecar/src/transport/mock.rs
+++ b/crates/sidecar/src/transport/mock.rs
@@ -1,3 +1,4 @@
+use crate::engine::queue::GetTransactionResultQueueSender;
 use crate::{
     engine::queue::{
         TransactionQueueReceiver,
@@ -22,6 +23,8 @@ pub struct MockTransport {
     /// Transactions sent to this channel will be forwarded
     /// to the core engine queue.
     mock_receiver: TransactionQueueReceiver,
+    /// Get transaction result queue sender.
+    _get_tx_result_sender: GetTransactionResultQueueSender,
 }
 
 impl MockTransport {
@@ -30,10 +33,12 @@ impl MockTransport {
     pub fn with_receiver(
         tx_sender: TransactionQueueSender,
         mock_receiver: TransactionQueueReceiver,
+        get_tx_result_sender: GetTransactionResultQueueSender,
     ) -> Self {
         Self {
             tx_sender,
             mock_receiver,
+            _get_tx_result_sender: get_tx_result_sender,
         }
     }
 }
@@ -42,12 +47,17 @@ impl Transport for MockTransport {
     type Error = MockTransportError;
     type Config = ();
 
-    fn new(_config: (), tx_sender: TransactionQueueSender) -> Result<Self, Self::Error> {
+    fn new(
+        _config: (),
+        tx_sender: TransactionQueueSender,
+        get_tx_result_sender: GetTransactionResultQueueSender,
+    ) -> Result<Self, Self::Error> {
         // Create a dummy receiver channel for the trait implementation
         let (_, mock_receiver) = crossbeam::channel::unbounded();
         Ok(Self {
             tx_sender,
             mock_receiver,
+            _get_tx_result_sender: get_tx_result_sender,
         })
     }
 

--- a/crates/sidecar/src/transport/mod.rs
+++ b/crates/sidecar/src/transport/mod.rs
@@ -21,7 +21,10 @@ pub mod decoder;
 pub mod http;
 pub mod mock;
 
-use crate::engine::queue::TransactionQueueSender;
+use crate::engine::queue::{
+    GetTransactionResultQueueSender,
+    TransactionQueueSender,
+};
 
 /// The `Transport` trait defines the interface for external communication adapters that
 /// forward transactions and block environments to the core engine.
@@ -76,7 +79,11 @@ pub trait Transport: Send + Sync {
     type Config: Send;
 
     /// Create a new transport instance with the given configuration and queue sender.
-    fn new(config: Self::Config, tx_sender: TransactionQueueSender) -> Result<Self, Self::Error>
+    fn new(
+        config: Self::Config,
+        tx_sender: TransactionQueueSender,
+        get_tx_result_sender: GetTransactionResultQueueSender,
+    ) -> Result<Self, Self::Error>
     where
         Self: Sized;
 


### PR DESCRIPTION
- Implements the getTransaction method call
- Create a new type in `TxQueueContents` called  `GetTxResult`
- Pass the sender oneshot to the engine in order to receive the response
- Process the response and format it accordingly
- Remove redundant Clone derives (which was making it harder to pass the oenshot channel around)
- For each transaction processed in the engine, check if the transport layer is waiting for a result