### PR TITLE
feat: implement framework for setting up and generating tests, easy transaction creation and checking for tx results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10527,12 +10527,22 @@ dependencies = [
  "rust-tracing",
  "serde",
  "serde_json",
+ "sidecar-test-macros",
  "sled",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber 0.3.19",
+]
+
+[[package]]
+name = "sidecar-test-macros"
+version = "0.4.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/assertion-executor",
     "crates/dapp-api-client",
     "crates/sidecar",
+    "crates/sidecar/src/utils/test-macros",
 ]
 exclude = ["fuzz"]
 resolver = "2"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -28,7 +28,6 @@ reqwest = { workspace = true, features = ["json"] }
 lazy_static = "1.5.0"
 assertion-da-client = { workspace = true }
 alloy-provider = { workspace = true }
-dashmap = "6.1.0"
 
 [features]
 testing = ["ctor"]

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = { workspace = true, features = ["json"] }
 lazy_static = "1.5.0"
 assertion-da-client = { workspace = true }
 alloy-provider = { workspace = true }
+dashmap = "6.1.0"
 
 [features]
 testing = ["ctor"]

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -34,3 +34,4 @@ testing = ["ctor"]
 
 [dev-dependencies]
 ctor = "0.5.0"
+sidecar-test-macros = { path = "src/utils/test-macros" }

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -344,10 +344,7 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
                     continue;
                 }
                 Err(crossbeam::channel::TryRecvError::Disconnected) => {
-                    error!(
-                        target = "engine",
-                        "Transaction queue channel disconnected"
-                    );
+                    error!(target = "engine", "Transaction queue channel disconnected");
                     return Err(EngineError::ChannelClosed);
                 }
             };

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -342,7 +342,9 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
     pub fn clone_transaction_results(&self) -> HashMap<B256, TransactionResult> {
         self.transaction_results
             .get_all_transaction_result()
-            .cloned()
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().clone()))
+            .collect()
     }
 
     /// Run the engine and process transactions and blocks received

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -49,11 +49,13 @@ use crate::TransactionsState;
 #[allow(unused_imports)]
 use assertion_executor::{
     AssertionExecutor,
+    ExecutorConfig,
     ExecutorError,
     db::overlay::OverlayDb,
     primitives::ExecutionResult,
     store::{
         AssertionState,
+        AssertionStore,
         AssertionStoreError,
     },
 };
@@ -148,11 +150,6 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
     #[cfg(test)]
     #[allow(dead_code)]
     pub fn new_test() -> Self {
-        use assertion_executor::{
-            ExecutorConfig,
-            store::AssertionStore,
-        };
-
         let (_, tx_receiver) = crossbeam::channel::unbounded();
         Self {
             state: OverlayDb::new(None, 64),

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -74,7 +74,9 @@ use revm::{
         B256,
     },
 };
-use std::{collections::HashMap, sync::Arc};
+#[cfg(test)]
+use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{
     debug,
     error,
@@ -137,12 +139,6 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
             block_env: None,
             transaction_results: state_results,
         }
-    }
-
-    /// Get a clone of the shared transaction results DashMap for testing
-    #[cfg(test)]
-    pub fn get_shared_results(&self) -> Arc<DashMap<B256, TransactionResult>> {
-        self.state_results.transaction_results.clone()
     }
 
     /// Creates a new `CoreEngine` for testing purposes.
@@ -330,7 +326,9 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
     /// Get transaction result by hash, returning a cloned value for test compatibility.
     #[cfg(test)]
     pub fn get_transaction_result_cloned(&self, tx_hash: &B256) -> Option<TransactionResult> {
-        self.state_results.transaction_results.get(tx_hash).map(|entry| entry.value().clone())
+        self.transaction_results
+            .get_transaction_result(tx_hash)
+            .map(|r| r.clone())
     }
 
     /// Get all transaction results for testing purposes.
@@ -342,7 +340,11 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
     /// Clone all transaction results for testing purposes.
     #[cfg(test)]
     pub fn clone_transaction_results(&self) -> HashMap<B256, TransactionResult> {
-        self.state_results.transaction_results.iter().map(|entry| (*entry.key(), entry.value().clone())).collect()
+        self.transaction_results
+            .get_all_transaction_result()
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().clone()))
+            .collect()
     }
 
     /// Run the engine and process transactions and blocks received

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -483,15 +483,16 @@ mod tests {
         }
     }
 
-
     #[crate::utils::engine_test]
-    async fn test_core_engine_functionality(mut instance: crate::utils::LocalInstance) {        
+    async fn test_core_engine_functionality(mut instance: crate::utils::LocalInstance) {
         // Send and verify a reverting CREATE transaction
         let tx_hash = instance.send_reverting_create_tx().await.unwrap();
 
         // Verify transaction reverted but was still valid (passed assertions)
         assert!(
-            instance.is_transaction_reverted_but_valid(&tx_hash).unwrap(),
+            instance
+                .is_transaction_reverted_but_valid(&tx_hash)
+                .unwrap(),
             "Transaction should revert but still be valid (pass assertions)"
         );
 
@@ -513,7 +514,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Send Block 2 with Transaction 2  
+        // Send Block 2 with Transaction 2
         let tx2_hash = instance
             .send_successful_create_tx(uint!(0_U256), Bytes::new())
             .await
@@ -541,7 +542,7 @@ mod tests {
         instance
             .send_and_verify_reverting_create_tx()
             .await
-            .unwrap();   
+            .unwrap();
     }
 
     #[test]

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -212,7 +212,7 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
             Err(e) => {
                 match e {
                     ExecutorError::ForkTxExecutionError(_) => {
-                        // Transaction validation errors (nonce, gas, funds, etc.) 
+                        // Transaction validation errors (nonce, gas, funds, etc.)
                         debug!(
                             target = "engine",
                             error = ?e,

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -342,9 +342,7 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
     pub fn clone_transaction_results(&self) -> HashMap<B256, TransactionResult> {
         self.transaction_results
             .get_all_transaction_result()
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect()
+            .cloned()
     }
 
     /// Run the engine and process transactions and blocks received

--- a/crates/sidecar/src/transport/http/server.rs
+++ b/crates/sidecar/src/transport/http/server.rs
@@ -413,7 +413,7 @@ fn into_transaction_result_response(
                         hash,
                         status: "halted".to_string(),
                         gas_used,
-                        error: Some(format!("Transaction halted: {:?}", reason)),
+                        error: Some(format!("Transaction halted: {reason:?}")),
                     }
                 }
             }
@@ -423,7 +423,7 @@ fn into_transaction_result_response(
                 hash,
                 status: "failed".to_string(),
                 gas_used: None,
-                error: Some(format!("Validation error: {}", error)),
+                error: Some(format!("Validation error: {error}")),
             }
         }
     }

--- a/crates/sidecar/src/transport/mock.rs
+++ b/crates/sidecar/src/transport/mock.rs
@@ -63,12 +63,14 @@ impl Transport for MockTransport {
     }
 
     async fn run(&self) -> Result<(), MockTransportError> {
+        tracing::debug!("MockTransport starting");
         loop {
             // Use tokio::task::yield_now() to make this async-friendly
             tokio::task::yield_now().await;
 
             match self.mock_receiver.try_recv() {
                 Ok(rax) => {
+                    tracing::debug!("MockTransport forwarding message to engine");
                     self.tx_sender
                         .send(rax)
                         .map_err(|_| MockTransportError::CoreSendError)?;
@@ -80,6 +82,7 @@ impl Transport for MockTransport {
                 }
                 Err(crossbeam::channel::TryRecvError::Disconnected) => {
                     // Channel closed, exit gracefully
+                    tracing::debug!("MockTransport channel disconnected, stopping");
                     break;
                 }
             }

--- a/crates/sidecar/src/transport/mock.rs
+++ b/crates/sidecar/src/transport/mock.rs
@@ -77,7 +77,7 @@ impl Transport for MockTransport {
                 }
                 Err(crossbeam::channel::TryRecvError::Empty) => {
                     // No data yet, yield and try again
-                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                    tokio::task::yield_now().await;
                     continue;
                 }
                 Err(crossbeam::channel::TryRecvError::Disconnected) => {

--- a/crates/sidecar/src/transport/mock.rs
+++ b/crates/sidecar/src/transport/mock.rs
@@ -65,9 +65,6 @@ impl Transport for MockTransport {
     async fn run(&self) -> Result<(), MockTransportError> {
         tracing::debug!("MockTransport starting");
         loop {
-            // Use tokio::task::yield_now() to make this async-friendly
-            tokio::task::yield_now().await;
-
             match self.mock_receiver.try_recv() {
                 Ok(rax) => {
                     tracing::debug!("MockTransport forwarding message to engine");

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -51,7 +51,6 @@ use revm::{
         TxKind,
         U256,
         address,
-        hex,
     },
 };
 use std::{
@@ -676,7 +675,7 @@ mod tests {
             .unwrap();
 
         instance.send_and_verify_successful_create_tx(caller, nonce + 1, uint!(0_U256), Bytes::new()).await.unwrap();
-        instance.send_and_verify_reverting_create_tx(caller, nonce).await.unwrap();
+        instance.send_and_verify_reverting_create_tx(caller, nonce + 2).await.unwrap();
     }
 
     #[crate::utils::engine_test]

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -350,7 +350,7 @@ impl LocalInstance {
         self.send_transaction(tx_hash, tx_env)?;
 
         // Wait for processing
-        self.wait_for_processing(Duration::from_millis(100)).await;
+        self.wait_for_processing(Duration::from_millis(2)).await;
 
         Ok(tx_hash)
     }
@@ -387,7 +387,7 @@ impl LocalInstance {
         self.send_transaction(tx_hash, tx_env)?;
 
         // Wait for processing
-        self.wait_for_processing(Duration::from_millis(100)).await;
+        self.wait_for_processing(Duration::from_millis(2)).await;
 
         self.reset_nonce(current_nonce);
 
@@ -429,7 +429,7 @@ impl LocalInstance {
         self.send_transaction(tx_hash, tx_env)?;
 
         // Wait for processing
-        self.wait_for_processing(Duration::from_millis(100)).await;
+        self.wait_for_processing(Duration::from_millis(2)).await;
 
         Ok(tx_hash)
     }
@@ -550,7 +550,7 @@ impl LocalInstance {
         self.send_transaction(hash_fail, tx_fail)?;
 
         // Wait for processing
-        self.wait_for_processing(Duration::from_millis(100)).await;
+        self.wait_for_processing(Duration::from_millis(2)).await;
 
         // Verify the second transaction failed assertions and was NOT committed
         if !self.is_transaction_invalid(&hash_fail)? {

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -108,20 +108,17 @@ impl LocalInstance {
 
         // Create default account that will be used by this instance
         let default_account = Address::from([0x01; 20]);
-        let mut default_account_info = AccountInfo::default();
-        default_account_info.balance = U256::MAX;
+        let default_account_info = AccountInfo { balance: U256::MAX, ..Default::default() };
         underlying_db.insert_account_info(default_account, default_account_info);
 
         // Fund common test accounts with maximum balance
         let default_caller = counter_call().caller;
-        let mut caller_account = AccountInfo::default();
-        caller_account.balance = U256::MAX;
+        let caller_account = AccountInfo { balance: U256::MAX, ..Default::default() };
         underlying_db.insert_account_info(default_caller, caller_account);
 
         // Fund test caller account
         let test_caller = Address::from([0x02; 20]);
-        let mut test_account = AccountInfo::default();
-        test_account.balance = U256::MAX;
+        let test_account = AccountInfo { balance: U256::MAX, ..Default::default() };
         underlying_db.insert_account_info(test_caller, test_account);
 
         let underlying_db = Arc::new(underlying_db);
@@ -131,7 +128,7 @@ impl LocalInstance {
         // Create assertion store and executor
         let assertion_store = Arc::new(
             AssertionStore::new_ephemeral()
-                .map_err(|e| format!("Failed to create assertion store: {}", e))?,
+                .map_err(|e| format!("Failed to create assertion store: {e}"))?,
         );
 
         // Insert counter assertion into store
@@ -206,7 +203,7 @@ impl LocalInstance {
         let result = self
             .mock_sender
             .send(TxQueueContents::Block(block_env))
-            .map_err(|e| format!("Failed to send block: {}", e));
+            .map_err(|e| format!("Failed to send block: {e}"));
         match &result {
             Ok(_) => info!("Successfully sent block to mock_sender"),
             Err(e) => error!("Failed to send block: {}", e),
@@ -220,7 +217,7 @@ impl LocalInstance {
         let queue_tx = QueueTransaction { tx_hash, tx_env };
         self.mock_sender
             .send(TxQueueContents::Tx(queue_tx))
-            .map_err(|e| format!("Failed to send transaction: {}", e))
+            .map_err(|e| format!("Failed to send transaction: {e}"))
     }
 
     /// Send a block with multiple transactions
@@ -284,7 +281,7 @@ impl LocalInstance {
         self.assertion_store
             .insert(address, assertion)
             .map(|_| ())
-            .map_err(|e| format!("Failed to insert assertion: {}", e))
+            .map_err(|e| format!("Failed to insert assertion: {e}"))
     }
 
     /// Create a simple test transaction using the default account
@@ -308,8 +305,7 @@ impl LocalInstance {
             .ok_or_else(|| "Cannot get mutable reference to database".to_string())?;
 
         for (address, balance) in accounts {
-            let mut account_info = AccountInfo::default();
-            account_info.balance = *balance;
+            let account_info = AccountInfo { balance: *balance, ..Default::default() };
             db.insert_account_info(*address, account_info);
         }
 
@@ -448,7 +444,7 @@ impl LocalInstance {
         let assertion = AssertionState::new_test(assertion_bytecode);
 
         self.insert_assertion(address, assertion)
-            .map_err(|e| format!("Failed to insert custom assertion {}: {}", artifact_name, e))
+            .map_err(|e| format!("Failed to insert custom assertion {artifact_name}: {e}"))
     }
 
     /// Get transaction result by hash

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -1,0 +1,289 @@
+
+use crate::{
+    engine::{
+        CoreEngine,
+        queue::{
+            TransactionQueueSender,
+            TxQueueContents,
+            QueueTransaction,
+        },
+    },
+    transport::{
+        Transport,
+        mock::MockTransport,
+    },
+};
+use assertion_executor::{
+    AssertionExecutor,
+    ExecutorConfig,
+    db::overlay::OverlayDb,
+    store::{AssertionState, AssertionStore},
+};
+use crossbeam::channel;
+use revm::{
+    context::{BlockEnv, TxEnv},
+    database::{CacheDB, EmptyDBTyped},
+    primitives::{Address, B256, Bytes, TxKind, U256},
+};
+use assertion_executor::primitives::AccountInfo;
+use std::{
+    sync::Arc,
+    time::Duration,
+};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn, error};
+
+/// Test database error type
+type TestDbError = std::convert::Infallible;
+
+/// Creates a test instance of the core engine with mock transport.
+/// This struct manages the lifecycle of a test engine instance.
+pub struct LocalInstance {
+    /// Channel for sending transactions and blocks to the mock transport
+    mock_sender: TransactionQueueSender,
+    /// The underlying database
+    db: Arc<CacheDB<EmptyDBTyped<TestDbError>>>,
+    /// The assertion store
+    assertion_store: Arc<AssertionStore>,
+    /// Transport task handle
+    transport_handle: Option<JoinHandle<()>>,
+    /// Engine task handle  
+    engine_handle: Option<JoinHandle<()>>,
+}
+
+impl LocalInstance {
+    /// Create a new local instance with mock transport
+    pub async fn new() -> Result<Self, String> {
+        info!("Creating LocalInstance with MockTransport");
+
+        // Create channels for communication
+        let (engine_tx, engine_rx) = channel::unbounded();
+        let (mock_tx, mock_rx) = channel::unbounded();
+
+        // Create the database and state
+        let underlying_db = Arc::new(CacheDB::new(EmptyDBTyped::default()));
+        let state = OverlayDb::new(Some(underlying_db.clone()), 1024);
+
+        // Create assertion store and executor
+        let assertion_store = Arc::new(
+            AssertionStore::new_ephemeral()
+                .map_err(|e| format!("Failed to create assertion store: {}", e))?
+        );
+        let assertion_executor = AssertionExecutor::new(
+            ExecutorConfig::default(),
+            (*assertion_store).clone(),
+        );
+
+        // Create the engine
+        let mut engine = CoreEngine::new(state, engine_rx, assertion_executor);
+        
+        // Spawn the engine task that manually processes items
+        // This mimics what the tests do - manually processing items from the queue
+        let engine_handle = tokio::spawn(async move {
+            info!("Engine task started, waiting for items...");
+            info!("Engine about to call run()");
+            let result = engine.run().await;
+            match result {
+                Ok(_) => info!("Engine run() completed successfully"),
+                Err(e) => error!("Engine run() failed: {:?}", e),
+            }
+            info!("Engine task completed");
+        });
+
+        // Create mock transport with the channels
+        let transport = MockTransport::with_receiver(engine_tx, mock_rx);
+        
+        // Spawn the transport task
+        let transport_handle = tokio::spawn(async move {
+            info!("Transport task started");
+            info!("Transport about to call run()");
+            let result = transport.run().await;
+            match result {
+                Ok(_) => info!("Transport run() completed successfully"),
+                Err(e) => warn!("Transport stopped with error: {}", e),
+            }
+            info!("Transport task completed");
+        });
+
+        Ok(Self {
+            mock_sender: mock_tx,
+            db: underlying_db,
+            assertion_store,
+            transport_handle: Some(transport_handle),
+            engine_handle: Some(engine_handle),
+        })
+    }
+
+    /// Send a new block environment to the engine
+    pub fn send_block(&self, block_env: BlockEnv) -> Result<(), String> {
+        info!("LocalInstance sending block: {:?}", block_env.number);
+        info!("About to send to mock_sender channel");
+        let result = self.mock_sender
+            .send(TxQueueContents::Block(block_env))
+            .map_err(|e| format!("Failed to send block: {}", e));
+        match &result {
+            Ok(_) => info!("Successfully sent block to mock_sender"),
+            Err(e) => error!("Failed to send block: {}", e),
+        }
+        result
+    }
+
+    /// Send a transaction to the engine
+    pub fn send_transaction(&self, tx_hash: B256, tx_env: TxEnv) -> Result<(), String> {
+        info!("LocalInstance sending transaction: {:?}", tx_hash);
+        let queue_tx = QueueTransaction { tx_hash, tx_env };
+        self.mock_sender
+            .send(TxQueueContents::Tx(queue_tx))
+            .map_err(|e| format!("Failed to send transaction: {}", e))
+    }
+
+    /// Send a block with multiple transactions
+    pub fn send_block_with_txs(
+        &self,
+        block_env: BlockEnv,
+        transactions: Vec<(B256, TxEnv)>,
+    ) -> Result<(), String> {
+        // Send the block environment first
+        self.send_block(block_env)?;
+
+        // Then send all transactions
+        for (tx_hash, tx_env) in transactions {
+            self.send_transaction(tx_hash, tx_env)?;
+        }
+
+        Ok(())
+    }
+
+    /// Get a reference to the underlying database
+    pub fn db(&self) -> &Arc<CacheDB<EmptyDBTyped<TestDbError>>> {
+        &self.db
+    }
+
+    /// Get a reference to the assertion store
+    pub fn assertion_store(&self) -> &Arc<AssertionStore> {
+        &self.assertion_store
+    }
+
+    /// Wait for a short time to allow transaction processing
+    /// Since we can't directly access engine results in this test setup,
+    /// tests should verify behavior through other means (e.g., state changes)
+    pub async fn wait_for_processing(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+
+    /// Insert an assertion into the store
+    pub fn insert_assertion(
+        &self,
+        address: Address,
+        assertion: AssertionState,
+    ) -> Result<(), String> {
+        self.assertion_store
+            .insert(address, assertion)
+            .map(|_| ())
+            .map_err(|e| format!("Failed to insert assertion: {}", e))
+    }
+
+    /// Create a test block environment with default values
+    pub fn create_test_block(&self, number: u64) -> BlockEnv {
+        BlockEnv {
+            number,
+            basefee: 0, // Set to 0 to avoid balance issues in tests
+            timestamp: 1_000_000 + number * 12,
+            gas_limit: 30_000_000,
+            ..Default::default()
+        }
+    }
+
+    /// Create a simple test transaction
+    pub fn create_test_transaction(
+        &self,
+        caller: Address,
+        nonce: u64,
+        value: U256,
+        data: Bytes,
+    ) -> TxEnv {
+        TxEnv {
+            caller,
+            gas_limit: 100_000,
+            gas_price: 0,
+            kind: TxKind::Create,
+            value,
+            data,
+            nonce,
+            ..Default::default()
+        }
+    }
+
+    /// Send a simple test transaction and wait for processing
+    pub async fn send_and_wait(&self, tx_hash: B256, tx_env: TxEnv) -> Result<(), String> {
+        self.send_transaction(tx_hash, tx_env)?;
+        self.wait_for_processing(Duration::from_millis(100)).await;
+        Ok(())
+    }
+
+    /// Prefund accounts with ETH for testing
+    pub fn fund_accounts(&mut self, accounts: &[(Address, U256)]) -> Result<(), String> {
+        let db = Arc::get_mut(&mut self.db)
+            .ok_or_else(|| "Cannot get mutable reference to database".to_string())?;
+        
+        for (address, balance) in accounts {
+            let mut account_info = AccountInfo::default();
+            account_info.balance = *balance;
+            db.insert_account_info(*address, account_info);
+        }
+        
+        Ok(())
+    }
+}
+
+impl Drop for LocalInstance {
+    fn drop(&mut self) {
+        // Abort tasks if still running
+        if let Some(handle) = self.transport_handle.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.engine_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::primitives::uint;
+
+    #[tokio::test]
+    async fn test_mock_driver_pattern_demonstration() {
+        // Create a mock instance for testing
+        info!("Creating LocalInstance for test");
+        let instance = LocalInstance::new().await.unwrap();
+        
+        // Send a block environment
+        info!("Sending block to engine");
+        let block = instance.create_test_block(1);
+        instance.send_block(block).unwrap();
+        
+        // Give transport time to forward the block
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        
+        // Create and send a transaction
+        info!("Sending transaction to engine");
+        let tx_env = instance.create_test_transaction(
+            Address::from([0x01; 20]),
+            0,
+            uint!(0_U256),
+            Bytes::new(),
+        );
+        
+        let tx_hash = B256::from([0x11; 32]);
+        instance.send_transaction(tx_hash, tx_env).unwrap();
+        
+        // Wait for processing
+        info!("Waiting for transaction processing");
+        instance.wait_for_processing(Duration::from_millis(100)).await;
+        
+        info!("Test completed successfully");
+        // Test passes if no panic/errors occurred during processing
+    }
+}

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -155,7 +155,8 @@ impl LocalInstance {
 
         // Create the engine with TransactionsState
         let state_results = crate::TransactionsState::new();
-        let mut engine = CoreEngine::new(state, engine_rx, assertion_executor, state_results.clone());
+        let mut engine =
+            CoreEngine::new(state, engine_rx, assertion_executor, state_results.clone());
 
         // Spawn the engine task that manually processes items
         // This mimics what the tests do - manually processing items from the queue

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -108,17 +108,26 @@ impl LocalInstance {
 
         // Create default account that will be used by this instance
         let default_account = Address::from([0x01; 20]);
-        let default_account_info = AccountInfo { balance: U256::MAX, ..Default::default() };
+        let default_account_info = AccountInfo {
+            balance: U256::MAX,
+            ..Default::default()
+        };
         underlying_db.insert_account_info(default_account, default_account_info);
 
         // Fund common test accounts with maximum balance
         let default_caller = counter_call().caller;
-        let caller_account = AccountInfo { balance: U256::MAX, ..Default::default() };
+        let caller_account = AccountInfo {
+            balance: U256::MAX,
+            ..Default::default()
+        };
         underlying_db.insert_account_info(default_caller, caller_account);
 
         // Fund test caller account
         let test_caller = Address::from([0x02; 20]);
-        let test_account = AccountInfo { balance: U256::MAX, ..Default::default() };
+        let test_account = AccountInfo {
+            balance: U256::MAX,
+            ..Default::default()
+        };
         underlying_db.insert_account_info(test_caller, test_account);
 
         let underlying_db = Arc::new(underlying_db);
@@ -305,7 +314,10 @@ impl LocalInstance {
             .ok_or_else(|| "Cannot get mutable reference to database".to_string())?;
 
         for (address, balance) in accounts {
-            let account_info = AccountInfo { balance: *balance, ..Default::default() };
+            let account_info = AccountInfo {
+                balance: *balance,
+                ..Default::default()
+            };
             db.insert_account_info(*address, account_info);
         }
 

--- a/crates/sidecar/src/utils/mod.rs
+++ b/crates/sidecar/src/utils/mod.rs
@@ -2,9 +2,14 @@
 //!
 //! Contains various shared utilities we use across the sidecar `mod`s:
 //! - `test_util` test utilites to set up and run tests.
+//! - `instance` test instance for running engine tests with mock transport
 
 #[cfg(test)]
 mod test_util;
+#[cfg(test)]
+pub mod instance;
 
 #[cfg(test)]
 pub use test_util::TestDbError;
+#[cfg(test)]
+pub use instance::LocalInstance;

--- a/crates/sidecar/src/utils/mod.rs
+++ b/crates/sidecar/src/utils/mod.rs
@@ -7,9 +7,10 @@
 #[cfg(test)]
 mod test_util;
 #[cfg(test)]
+#[allow(dead_code)]
 pub mod instance;
 
 #[cfg(test)]
-pub use test_util::TestDbError;
+pub use test_util::{TestDbError, engine_test};
 #[cfg(test)]
 pub use instance::LocalInstance;

--- a/crates/sidecar/src/utils/mod.rs
+++ b/crates/sidecar/src/utils/mod.rs
@@ -5,12 +5,15 @@
 //! - `instance` test instance for running engine tests with mock transport
 
 #[cfg(test)]
-mod test_util;
-#[cfg(test)]
 #[allow(dead_code)]
 pub mod instance;
+#[cfg(test)]
+mod test_util;
 
 #[cfg(test)]
-pub use test_util::{TestDbError, engine_test};
-#[cfg(test)]
 pub use instance::LocalInstance;
+#[cfg(test)]
+pub use test_util::{
+    TestDbError,
+    engine_test,
+};

--- a/crates/sidecar/src/utils/test-macros/Cargo.toml
+++ b/crates/sidecar/src/utils/test-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sidecar-test-macros"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full", "extra-traits"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/crates/sidecar/src/utils/test-macros/src/lib.rs
+++ b/crates/sidecar/src/utils/test-macros/src/lib.rs
@@ -18,6 +18,19 @@ use syn::{
 ///     // Your test code here
 /// }
 /// ```
+// TODO: we should expand this macro to generate tests for multiple transports.
+// For example, we can from one test generate multiple tests for different transports
+// if we genericize `LocalInstnace` to accept different transports. The syntax would
+// then look something like:
+// ```
+// #[engine_test(all)] // can also specify transports for testing only specific ones
+// async fn test_transaction_processing(mut instance: LocalInstance) {
+//     instance.new_block().unwrap();
+//     // Your test code here
+// }
+// ```
+// and would generate tests test_transaction_processing_mock,
+// test_transaction_processing_http, etc...
 #[proc_macro_attribute]
 pub fn engine_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input_fn = parse_macro_input!(item as ItemFn);

--- a/crates/sidecar/src/utils/test-macros/src/lib.rs
+++ b/crates/sidecar/src/utils/test-macros/src/lib.rs
@@ -1,0 +1,41 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+/// Procedural macro for sidecar engine tests.
+/// 
+/// This macro automatically creates a LocalInstance and passes it to your test function.
+/// The test function must be async and take a single parameter of type LocalInstance.
+/// 
+/// # Example
+/// ```
+/// #[engine_test]
+/// async fn test_transaction_processing(mut instance: LocalInstance) {
+///     instance.new_block().unwrap();
+///     // Your test code here
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn engine_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input_fn = parse_macro_input!(item as ItemFn);
+    
+    let fn_name = &input_fn.sig.ident;
+    let fn_body = &input_fn.block;
+    let fn_vis = &input_fn.vis;
+    
+    let output = quote! {
+        #[tokio::test]
+        #fn_vis async fn #fn_name() {
+            use crate::utils::LocalInstance;
+            
+            let mut instance = LocalInstance::new()
+                .await
+                .expect("Failed to create LocalInstance");
+            
+            let test_fn = |mut instance: LocalInstance| async move #fn_body;
+            test_fn(instance).await;
+        }
+    };
+    
+    TokenStream::from(output)
+}

--- a/crates/sidecar/src/utils/test-macros/src/lib.rs
+++ b/crates/sidecar/src/utils/test-macros/src/lib.rs
@@ -1,12 +1,15 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, ItemFn};
+use syn::{
+    ItemFn,
+    parse_macro_input,
+};
 
 /// Procedural macro for sidecar engine tests.
-/// 
+///
 /// This macro automatically creates a LocalInstance and passes it to your test function.
 /// The test function must be async and take a single parameter of type LocalInstance.
-/// 
+///
 /// # Example
 /// ```
 /// #[engine_test]
@@ -18,24 +21,24 @@ use syn::{parse_macro_input, ItemFn};
 #[proc_macro_attribute]
 pub fn engine_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input_fn = parse_macro_input!(item as ItemFn);
-    
+
     let fn_name = &input_fn.sig.ident;
     let fn_body = &input_fn.block;
     let fn_vis = &input_fn.vis;
-    
+
     let output = quote! {
         #[tokio::test]
         #fn_vis async fn #fn_name() {
             use crate::utils::LocalInstance;
-            
+
             let mut instance = LocalInstance::new()
                 .await
                 .expect("Failed to create LocalInstance");
-            
+
             let test_fn = |mut instance: LocalInstance| async move #fn_body;
             test_fn(instance).await;
         }
     };
-    
+
     TokenStream::from(output)
 }

--- a/crates/sidecar/src/utils/test_util.rs
+++ b/crates/sidecar/src/utils/test_util.rs
@@ -41,14 +41,14 @@ use std::convert::Infallible;
 pub type TestDbError = Infallible;
 
 /// Re-export the engine_test procedural macro
-/// 
+///
 /// This macro simplifies test setup by automatically creating a LocalInstance
 /// and passing it to your test function.
-/// 
+///
 /// # Usage
 /// ```
 /// use sidecar::utils::engine_test;
-/// 
+///
 /// #[engine_test]
 /// async fn test_something(mut instance: LocalInstance) {
 ///     instance.new_block().unwrap();

--- a/crates/sidecar/src/utils/test_util.rs
+++ b/crates/sidecar/src/utils/test_util.rs
@@ -39,3 +39,20 @@ use std::convert::Infallible;
 
 /// Error type used in tests, infallible for simplicity
 pub type TestDbError = Infallible;
+
+/// Re-export the engine_test procedural macro
+/// 
+/// This macro simplifies test setup by automatically creating a LocalInstance
+/// and passing it to your test function.
+/// 
+/// # Usage
+/// ```
+/// use sidecar::utils::engine_test;
+/// 
+/// #[engine_test]
+/// async fn test_something(mut instance: LocalInstance) {
+///     instance.new_block().unwrap();
+///     // Your test code here
+/// }
+/// ```
+pub use sidecar_test_macros::engine_test;


### PR DESCRIPTION
- Implements `LocalInstance` which holds data needed to run a core engine and transport.
- `LocalInstance` contains helper methods for easy transaction sending and validation. It an send various kinds of transactions, and check if assertion validation works as intended.
- Implements `engine_test` macro which sets up `LocalInstance` and creates a framework for generating tests.
- The syntax for creating a test looks like this, with localinstance containing everything needed to run the sidecar:
```rust
 #[engine_test]
 async fn test_transaction_processing(mut instance: LocalInstance) {
     instance.new_block().unwrap();
     // Your test code here
}
```