### PR TITLE
feat(assex): implement linea spec opcodes and precompile behavior as inspectors

### DIFF
--- a/.github/workflows/rust-test-lint.yml
+++ b/.github/workflows/rust-test-lint.yml
@@ -36,6 +36,6 @@ jobs:
       foundry-command: 'forge build --root testdata/mock-protocol'
       # [""] means default features
       # Feature matrices are supported as follows: ["", "--features=foo", "--features=bar", "--features=foo,bar"]
-      feature-sets: '["", "--no-default-features"]'
+      feature-sets: '["", "--no-default-features --features=linea", "--no-default-features"]'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ assertion-da-server = { path = "crates/assertion-da/da-server" }
 int-test-utils = { path = "crates/int-test-utils" }
 
 # assertion-executor
-assertion-executor = { path = "crates/assertion-executor" }
+assertion-executor = { path = "crates/assertion-executor",  default-features = false }
 
 anyhow = "1.0.86"
 clap = { version = "4.5.11", features = ["derive", "env"] }

--- a/crates/assertion-executor/Cargo.toml
+++ b/crates/assertion-executor/Cargo.toml
@@ -52,8 +52,9 @@ evm-glue = { workspace = true }
 
 
 [features]
-default = ["optimism", "full-test"]
+default = ["full-test"]
 optimism = []
+linea = []
 phoundry = ["revm/optional_eip3607"]
 test = ["serde_json", "rand"]
 serde_json = []
@@ -68,7 +69,7 @@ assertion-da-server = { workspace = true }
 criterion = { workspace = true }
 bollard = { workspace = true }
 int-test-utils = { workspace = true }
-assertion-executor = { path = ".", features = ["test"] }
+assertion-executor = { path = ".", default-features = false, features = ["test"] }
 futures = { workspace = true }
 anyhow = { workspace = true }
 evm-glue = { workspace = true }

--- a/crates/assertion-executor/src/evm/build_evm.rs
+++ b/crates/assertion-executor/src/evm/build_evm.rs
@@ -126,7 +126,7 @@ where
 }
 pub type EthCtx<'db, DB> =
     Context<BlockEnv, TxEnv, CfgEnv<SpecId>, &'db mut DB, Journal<&'db mut DB>, ()>;
-type EthIns<'db, DB> = EthInstructions<EthInterpreter, EthCtx<'db, DB>>;
+pub type EthIns<'db, DB> = EthInstructions<EthInterpreter, EthCtx<'db, DB>>;
 type EthEvm<'db, DB, I> = Evm<EthCtx<'db, DB>, I, EthIns<'db, DB>, PrecompilesMap>;
 
 /// Builds a mainnet Ethereum EVM, using all mainnet related types.

--- a/crates/assertion-executor/src/evm/build_evm.rs
+++ b/crates/assertion-executor/src/evm/build_evm.rs
@@ -299,7 +299,15 @@ mod tests {
 
         let inspector = PhEvmInspector::new(phvem_context);
 
-        #[cfg(feature = "optimism")]
+        #[cfg(feature = "linea")]
+        let (mut evm, tx_env) = {
+            let env = evm_env(1, SpecId::default(), BlockEnv::default());
+            (
+                crate::evm::linea::build_linea_evm(&mut multi_fork_db, &env, inspector),
+                tx_env,
+            )
+        };
+        #[cfg(all(feature = "optimism", not(feature = "linea")))]
         let (mut evm, tx_env) = {
             let env = evm_env(1, SpecId::default(), BlockEnv::default());
             (
@@ -307,10 +315,10 @@ mod tests {
                 OpTransaction::new(tx_env),
             )
         };
-        #[cfg(not(feature = "optimism"))]
-        let mut evm = {
+        #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
+        let (mut evm, tx_env) = {
             let env = evm_env(1, SpecId::default(), BlockEnv::default());
-            build_eth_evm(&mut multi_fork_db, &env, inspector)
+            (build_eth_evm(&mut multi_fork_db, &env, inspector), tx_env)
         };
 
         if with_reprice {

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -2,12 +2,8 @@
 //!
 //! Contains types needed to initialize a linea spec of revm.
 
-use crate::evm::{
-    linea::opcodes::insert_linea_instructions,
-};
-use alloy_evm::{
-    EvmEnv,
-};
+use crate::evm::linea::opcodes::insert_linea_instructions;
+use alloy_evm::EvmEnv;
 use revm::{
     Context,
     Database,

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -1,6 +1,6 @@
 //! # `evm`
 //!
-//! Contains types needed to initialize a linea version of revm.
+//! Contains types needed to initialize a linea spec of revm.
 
 use crate::evm::linea::opcodes::insert_linea_instructions;
 use revm::{
@@ -30,9 +30,18 @@ use revm::{
     },
 };
 
-/// LineaEvm variant of the EVM.
+/// LineaEvm is a Linea v4 spec version of revm with custom opcodes and precompile
+/// behaviour.
+///
+/// # Usage and differences
+/// `LineaEvm` has the exact same API as you would creating a regular revm evm.
+/// In the `new` fn, we replace certain instructions with how they are implemented
+/// on linea. We also wrap the inspector that gets passed into the new function with
+/// our own linea inspector that implements functionality of those matching linea v4.
+/// 
+/// # Executing transactions
 /// To implement our *own* evm we needed to wrap the Linea evm in a struct.
-/// It can be interacter like so: `linea_evm.0.transact(tx_env)`
+/// It can be interacted with like so: `linea_evm.0.transact(tx_env)`
 pub struct LineaEvm<CTX, INSP>(
     pub Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles>,
 );

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -157,6 +157,13 @@ where
     }
 }
 
+/// Builds a Linea EVM enviroment. Replaces specific opcodes with their linea compatible counterparts.
+///
+/// ***IMPORTANT:*** To get linea precompile functionality, you must use either the `CallTracer` or `PhEvmInspector` inspectors.
+///
+/// The `chain_id` is used to set the chain ID in the EVM environment.
+/// The `spec_id` is used to set the spec ID in the EVM environment.
+/// The `block_env` is used to set the block environment in the EVM environment.
 pub fn build_linea_evm<'db, DB, I>(
     db: &'db mut DB,
     env: &EvmEnv,

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -47,7 +47,9 @@ use std::marker::PhantomData;
 
 pub type LineaCtx<'db, DB> =
     Context<BlockEnv, TxEnv, CfgEnv<SpecId>, &'db mut DB, Journal<&'db mut DB>, PhantomData<()>>;
+#[allow(dead_code)]
 pub type LineaIns<'db, DB> = EthInstructions<EthInterpreter, LineaCtx<'db, DB>>;
+#[allow(dead_code)]
 type LineaEvmTyped<'db, DB, I> = Evm<LineaCtx<'db, DB>, I, LineaIns<'db, DB>, EthPrecompiles>;
 
 /// LineaEvm is a Linea v4 spec version of revm with custom opcodes and precompile
@@ -62,7 +64,7 @@ type LineaEvmTyped<'db, DB, I> = Evm<LineaCtx<'db, DB>, I, LineaIns<'db, DB>, Et
 /// # IMPORTANT: tracer and precompiles
 /// Linea has some minor precompile changes to precompiles. We have implemented such
 /// changes within an inspector. ***To get full linea precompile changes, you must use
-/// either the `CallTracer` or `PhEvm` inspectors!!!.***
+/// either the `CallTracer` or `PhEvmInspector` inspectors!!!.***
 ///
 /// # Executing transactions
 /// To implement our *own* evm we needed to wrap the Linea evm in a struct.

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -1,0 +1,120 @@
+//! # `evm`
+//!
+//! Contains types needed to initialize a linea version of revm.
+
+use crate::evm::linea::opcodes::insert_linea_instructions;
+use revm::{
+    Inspector,
+    context::{
+        ContextSetters,
+        ContextTr,
+        Evm,
+    },
+    handler::{
+        EthPrecompiles,
+        EvmTr,
+        instructions::{
+            EthInstructions,
+            InstructionProvider,
+        },
+    },
+    inspector::{
+        InspectorEvmTr,
+        JournalExt,
+        inspect_instructions,
+    },
+    interpreter::{
+        Interpreter,
+        InterpreterTypes,
+        interpreter::EthInterpreter,
+    },
+};
+
+/// LineaEvm variant of the EVM.
+pub struct LineaEvm<CTX, INSP>(
+    pub Evm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, EthPrecompiles>,
+);
+
+impl<CTX: ContextTr, INSP> LineaEvm<CTX, INSP> {
+    pub fn new(ctx: CTX, inspector: INSP) -> Self {
+        let mut instruction = EthInstructions::new_mainnet();
+        insert_linea_instructions(&mut instruction).unwrap();
+
+        Self(Evm {
+            ctx,
+            inspector,
+            instruction,
+            precompiles: EthPrecompiles::default(),
+        })
+    }
+}
+
+impl<CTX: ContextTr, INSP> EvmTr for LineaEvm<CTX, INSP>
+where
+    CTX: ContextTr,
+{
+    type Context = CTX;
+    type Instructions = EthInstructions<EthInterpreter, CTX>;
+    type Precompiles = EthPrecompiles;
+
+    fn ctx(&mut self) -> &mut Self::Context {
+        &mut self.0.ctx
+    }
+
+    fn ctx_ref(&self) -> &Self::Context {
+        self.0.ctx_ref()
+    }
+
+    fn ctx_instructions(&mut self) -> (&mut Self::Context, &mut Self::Instructions) {
+        self.0.ctx_instructions()
+    }
+
+    fn run_interpreter(
+        &mut self,
+        interpreter: &mut Interpreter<
+            <Self::Instructions as InstructionProvider>::InterpreterTypes,
+        >,
+    ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
+    {
+        self.0.run_interpreter(interpreter)
+    }
+
+    fn ctx_precompiles(&mut self) -> (&mut Self::Context, &mut Self::Precompiles) {
+        self.0.ctx_precompiles()
+    }
+}
+
+impl<CTX: ContextTr, INSP> InspectorEvmTr for LineaEvm<CTX, INSP>
+where
+    CTX: ContextSetters<Journal: JournalExt>,
+    INSP: Inspector<CTX, EthInterpreter>,
+{
+    type Inspector = INSP;
+
+    fn inspector(&mut self) -> &mut Self::Inspector {
+        self.0.inspector()
+    }
+
+    fn ctx_inspector(&mut self) -> (&mut Self::Context, &mut Self::Inspector) {
+        self.0.ctx_inspector()
+    }
+
+    fn run_inspect_interpreter(
+        &mut self,
+        interpreter: &mut Interpreter<
+            <Self::Instructions as InstructionProvider>::InterpreterTypes,
+        >,
+    ) -> <<Self::Instructions as InstructionProvider>::InterpreterTypes as InterpreterTypes>::Output
+    {
+        let context = &mut self.0.ctx;
+        let instructions = &mut self.0.instruction;
+        let inspector = &mut self.0.inspector;
+
+        inspect_instructions(
+            context,
+            interpreter,
+            inspector,
+            instructions.instruction_table(),
+        )
+    }
+}

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -214,7 +214,10 @@ mod tests {
         let spec = env.cfg_env.spec;
         let context = Context {
             journaled_state: {
-                let mut journal = crate::primitives::Journal::new_with_inner(&mut multi_fork_db, JournalInner::<JournalEntry>::new());
+                let mut journal = crate::primitives::Journal::new_with_inner(
+                    &mut multi_fork_db,
+                    JournalInner::<JournalEntry>::new(),
+                );
                 journal.set_spec_id(spec);
                 journal
             },
@@ -225,7 +228,7 @@ mod tests {
             local: LocalContext::default(),
             error: Ok(()),
         };
-        
+
         let mut linea_evm = LineaEvm::new(context, inspector);
 
         linea_evm.0.transact(tx_env).unwrap().result
@@ -275,7 +278,10 @@ mod tests {
         let spec = env.cfg_env.spec;
         let context = Context {
             journaled_state: {
-                let mut journal = crate::primitives::Journal::new_with_inner(&mut multi_fork_db, JournalInner::<JournalEntry>::new());
+                let mut journal = crate::primitives::Journal::new_with_inner(
+                    &mut multi_fork_db,
+                    JournalInner::<JournalEntry>::new(),
+                );
                 journal.set_spec_id(spec);
                 journal
             },
@@ -287,7 +293,7 @@ mod tests {
             error: Ok(()),
         };
         let linea_evm = LineaEvm::new(context, inspector);
-        
+
         // Verify the EVM was created successfully and has Linea instructions
         assert!(!linea_evm.0.instruction.instruction_table().is_empty());
     }

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -60,7 +60,7 @@ type LineaEvmTyped<'db, DB, I> = Evm<LineaCtx<'db, DB>, I, LineaIns<'db, DB>, Et
 /// # IMPORTANT: tracer and precompiles
 /// Linea has some minor precompile changes to precompiles. We have implemented such
 /// changes within an inspector. ***To get full linea precompile changes, you must use
-/// either the `CallTracer` or `PhEvmInspector` inspectors!!!.***
+/// either the `CallTracer`, `TriggerRecorder` or `PhEvmInspector` inspectors!!!.***
 ///
 /// # Executing transactions
 /// To implement our *own* evm we needed to wrap the Linea evm in a struct.
@@ -155,7 +155,8 @@ where
 
 /// Builds a Linea EVM enviroment. Replaces specific opcodes with their linea compatible counterparts.
 ///
-/// ***IMPORTANT:*** To get linea precompile functionality, you must use either the `CallTracer` or `PhEvmInspector` inspectors.
+/// ***IMPORTANT:*** To get linea precompile functionality, you must use either the `CallTracer`,
+/// `TriggerRecorder` or `PhEvmInspector` inspectors.
 ///
 /// The `chain_id` is used to set the chain ID in the EVM environment.
 /// The `spec_id` is used to set the spec ID in the EVM environment.

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -3,12 +3,10 @@
 //! Contains types needed to initialize a linea spec of revm.
 
 use crate::evm::{
-    build_evm::EthIns,
     linea::opcodes::insert_linea_instructions,
 };
 use alloy_evm::{
     EvmEnv,
-    eth::EthEvmContext,
 };
 use revm::{
     Context,
@@ -60,6 +58,11 @@ type LineaEvmTyped<'db, DB, I> = Evm<LineaCtx<'db, DB>, I, LineaIns<'db, DB>, Et
 /// In the `new` fn, we replace certain instructions with how they are implemented
 /// on linea. We also wrap the inspector that gets passed into the new function with
 /// our own linea inspector that implements functionality of those matching linea v4.
+///
+/// # IMPORTANT: tracer and precompiles
+/// Linea has some minor precompile changes to precompiles. We have implemented such
+/// changes within an inspector. ***To get full linea precompile changes, you must use
+/// either the `CallTracer` or `PhEvm` inspectors!!!.***
 ///
 /// # Executing transactions
 /// To implement our *own* evm we needed to wrap the Linea evm in a struct.

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -38,7 +38,7 @@ pub struct LineaEvm<CTX, INSP>(
 impl<CTX: ContextTr, INSP> LineaEvm<CTX, INSP> {
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
         let mut instruction = EthInstructions::new_mainnet();
-        insert_linea_instructions(&mut instruction).unwrap();
+        insert_linea_instructions(&mut instruction);
 
         Self(Evm {
             ctx,

--- a/crates/assertion-executor/src/evm/linea/mod.rs
+++ b/crates/assertion-executor/src/evm/linea/mod.rs
@@ -2,4 +2,7 @@ mod evm;
 pub(crate) mod opcodes;
 mod precompiles;
 
-pub use evm::{LineaEvm, build_linea_evm};
+pub use evm::{
+    LineaEvm,
+    build_linea_evm,
+};

--- a/crates/assertion-executor/src/evm/linea/mod.rs
+++ b/crates/assertion-executor/src/evm/linea/mod.rs
@@ -1,4 +1,5 @@
 mod evm;
 pub(crate) mod opcodes;
+mod precompiles;
 
 pub use evm::LineaEvm;

--- a/crates/assertion-executor/src/evm/linea/mod.rs
+++ b/crates/assertion-executor/src/evm/linea/mod.rs
@@ -2,4 +2,4 @@ mod evm;
 pub(crate) mod opcodes;
 mod precompiles;
 
-pub use evm::LineaEvm;
+pub use evm::{LineaEvm, build_linea_evm};

--- a/crates/assertion-executor/src/evm/linea/mod.rs
+++ b/crates/assertion-executor/src/evm/linea/mod.rs
@@ -1,0 +1,2 @@
+pub mod evm;
+pub(crate) mod opcodes;

--- a/crates/assertion-executor/src/evm/linea/mod.rs
+++ b/crates/assertion-executor/src/evm/linea/mod.rs
@@ -1,2 +1,4 @@
-pub mod evm;
+mod evm;
 pub(crate) mod opcodes;
+
+pub use evm::LineaEvm;

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -25,7 +25,7 @@ use revm::{
 
 /// Inserts linea specific instructions into an Eth instruction table.
 /// We replace certain opcodes to match the linea spec of revm.
-// FIXME: this is ideally implemented as an instructionprovider but this is easier
+// TODO: this is ideally implemented as an instructionprovider but this is easier
 pub fn insert_linea_instructions<WIRE, HOST>(instructions: &mut EthInstructions<WIRE, HOST>) -> ()
 where
     WIRE: InterpreterTypes,

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -26,9 +26,7 @@ use revm::{
 /// Inserts linea specific instructions into an Eth instruction table.
 /// We replace certain opcodes to match the linea spec of revm.
 // FIXME: this is ideally implemented as an instructionprovider but this is easier
-pub fn insert_linea_instructions<WIRE, HOST>(
-    instructions: &mut EthInstructions<WIRE, HOST>,
-) -> ()
+pub fn insert_linea_instructions<WIRE, HOST>(instructions: &mut EthInstructions<WIRE, HOST>) -> ()
 where
     WIRE: InterpreterTypes,
     HOST: Host,
@@ -62,9 +60,7 @@ pub fn linea_blob_basefee<WIRE: InterpreterTypes, HOST: Host>(
     interpreter: &mut Interpreter<WIRE>,
     host: &mut HOST,
 ) {
-    if let Some(_index) = interpreter.stack.pop() {
-        let _ = interpreter.stack.push(host.blob_gasprice());
-    }
+    let _ = interpreter.stack.push(host.blob_gasprice());
 }
 
 /// Implements the linea DIFFICULTY/PREVRANDAO instruction.
@@ -82,6 +78,7 @@ pub fn linea_difficulty<WIRE: InterpreterTypes, HOST: Host>(
     if prevrandao.is_none() {
         // if first block/no prevrandao we can just ret 0
         let _ = interpreter.stack.push(revm::primitives::U256::ZERO);
+        return;
     }
 
     // get the slot number
@@ -91,7 +88,140 @@ pub fn linea_difficulty<WIRE: InterpreterTypes, HOST: Host>(
     // now xor them
     let linea_prevrandao = prevrandao.unwrap().bitxor(hashed_slot.into());
 
-    if let Some(_index) = interpreter.stack.pop() {
-        let _ = interpreter.stack.push(linea_prevrandao);
+    let _ = interpreter.stack.push(linea_prevrandao);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+    use revm::{
+        interpreter::{
+            SharedMemory,
+            Stack,
+            host::DummyHost,
+            interpreter::{
+                EthInterpreter,
+                ExtBytecode,
+            },
+        },
+        primitives::hardfork::SpecId,
+        state::Bytecode,
+    };
+
+    #[test]
+    fn test_linea_blob_hash_returns_zero() {
+        // Create a minimal stack for testing
+        let mut stack = Stack::new();
+        let _ = stack.push(U256::from(1));
+
+        // Create interpreter with the stack
+        let mut interpreter = create_test_interpreter(stack);
+
+        let mut host = DummyHost;
+        linea_blob_hash(&mut interpreter, &mut host);
+
+        // Should have popped the index and pushed 0
+        assert_eq!(interpreter.stack.len(), 1);
+        assert_eq!(interpreter.stack.peek(0).unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn test_linea_blob_hash_with_different_indices() {
+        // Test with different indices - all should return 0
+        for index in [0u64, 1u64, 255u64] {
+            let mut stack = Stack::new();
+            let _ = stack.push(U256::from(index));
+
+            let mut interpreter = create_test_interpreter(stack);
+            let mut host = DummyHost;
+
+            linea_blob_hash(&mut interpreter, &mut host);
+
+            assert_eq!(interpreter.stack.len(), 1);
+            assert_eq!(
+                interpreter.stack.peek(0).unwrap(),
+                U256::ZERO,
+                "Index {} should return 0",
+                index
+            );
+        }
+    }
+
+    #[test]
+    fn test_linea_blob_basefee_behavior() {
+        let stack = Stack::new();
+        let mut interpreter = create_test_interpreter(stack);
+
+        let mut host = DummyHost;
+
+        linea_blob_basefee(&mut interpreter, &mut host);
+
+        // Should have pushed the blob gas price from DummyHost
+        assert_eq!(interpreter.stack.len(), 1);
+        // DummyHost returns U256::ZERO for blob_gasprice by default
+        assert_eq!(interpreter.stack.peek(0).unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn test_linea_difficulty_behavior() {
+        let stack = Stack::new();
+        let mut interpreter = create_test_interpreter(stack);
+
+        let mut host = DummyHost;
+
+        linea_difficulty(&mut interpreter, &mut host);
+
+        // Should have pushed a value (DummyHost has prevrandao None, so should return 0)
+        assert_eq!(interpreter.stack.len(), 1);
+        assert_eq!(interpreter.stack.peek(0).unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn test_linea_opcodes_execution_no_panic() {
+        // Integration test to ensure all opcodes execute without panicking
+        let mut stack = Stack::new();
+
+        // Add an index for BLOBHASH
+        let _ = stack.push(U256::from(1));
+
+        let mut interpreter = create_test_interpreter(stack);
+        let mut host = DummyHost;
+
+        // Test BLOBHASH
+        linea_blob_hash(&mut interpreter, &mut host);
+
+        // Test BLOBBASEFEE
+        linea_blob_basefee(&mut interpreter, &mut host);
+
+        // Test DIFFICULTY
+        linea_difficulty(&mut interpreter, &mut host);
+
+        // Should have 3 values on stack now
+        assert_eq!(interpreter.stack.len(), 3);
+
+        // All should be 0 from DummyHost
+        assert_eq!(interpreter.stack.peek(0).unwrap(), U256::ZERO); // DIFFICULTY
+        assert_eq!(interpreter.stack.peek(1).unwrap(), U256::ZERO); // BLOBBASEFEE
+        assert_eq!(interpreter.stack.peek(2).unwrap(), U256::ZERO); // BLOBHASH
+    }
+
+    // Helper function to create a test interpreter
+    fn create_test_interpreter(stack: Stack) -> revm::interpreter::Interpreter<EthInterpreter> {
+        let memory = SharedMemory::new();
+        let bytecode = ExtBytecode::new(Bytecode::default());
+        let inputs = Default::default();
+        let is_static = false;
+        let is_eof = false;
+        let spec_id = SpecId::OSAKA;
+        let gas_limit = 1000000u64;
+
+        let mut interpreter = revm::interpreter::Interpreter::new(
+            memory, bytecode, inputs, is_static, is_eof, spec_id, gas_limit,
+        );
+
+        // Replace the default stack with our test stack
+        interpreter.stack = stack;
+        interpreter
     }
 }

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -26,7 +26,7 @@ use revm::{
 /// Inserts linea specific instructions into an Eth instruction table.
 /// We replace certain opcodes to match the linea spec of revm.
 // TODO: this is ideally implemented as an instructionprovider but this is easier
-pub fn insert_linea_instructions<WIRE, HOST>(instructions: &mut EthInstructions<WIRE, HOST>) -> ()
+pub fn insert_linea_instructions<WIRE, HOST>(instructions: &mut EthInstructions<WIRE, HOST>)
 where
     WIRE: InterpreterTypes,
     HOST: Host,

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -54,13 +54,13 @@ pub fn linea_blob_hash<WIRE: InterpreterTypes, HOST: Host>(
 
 /// EIP-7516: BLOBBASEFEE opcode
 ///
-/// The linea version of BLOBBASEFEE returns the minimum value
-// FIXME: this is ambigous, we need to clarify what `minimum value means`. returning blob_gasprice for now
+/// The linea version of BLOBBASEFEE returns the minimum value.
+/// The minimum value is always `1_u256`.
 pub fn linea_blob_basefee<WIRE: InterpreterTypes, HOST: Host>(
     interpreter: &mut Interpreter<WIRE>,
-    host: &mut HOST,
+    _host: &mut HOST,
 ) {
-    let _ = interpreter.stack.push(host.blob_gasprice());
+    let _ = interpreter.stack.push(revm::primitives::U256::from(1));
 }
 
 /// Implements the linea DIFFICULTY/PREVRANDAO instruction.

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -213,7 +213,7 @@ mod tests {
         let inputs = Default::default();
         let is_static = false;
         let is_eof = false;
-        let spec_id = SpecId::OSAKA;
+        let spec_id = SpecId::PRAGUE;
         let gas_limit = 1000000u64;
 
         let mut interpreter = revm::interpreter::Interpreter::new(

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -1,0 +1,25 @@
+//! # `opcodes`
+//!
+//! Contains setup fns and implementations of linea specific opcodes.
+
+use revm::{
+    handler::instructions::EthInstructions,
+    interpreter::{
+        Host,
+        InterpreterTypes,
+    },
+};
+
+/// Inserts linea specific instructions into an Eth instruction table.
+/// We replace certain opcodes to match the linea spec of revm.
+// FIXME: this is ideally implemented as an instructionprovider but this is easier
+pub fn insert_linea_instructions<WIRE, HOST>(
+    instructions: &mut EthInstructions<WIRE, HOST>,
+) -> Result<(), ()>
+where
+    WIRE: InterpreterTypes,
+    HOST: Host,
+{
+    unimplemented!()
+}
+

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -1,12 +1,25 @@
-//! # `opcodes`
+//! # Linea specific `opcodes`
 //!
-//! Contains setup fns and implementations of linea specific opcodes.
+//! Contains setup fns and implementations of linea specific opcodes. Linea contains a few changes
+//! to opcode behavior. We target the final v4 spec of the linea evm. Compared to Osaka,
+//! which the linea evm is based on, The changes are as follows:
+//! - **BLOBBASEFEE** - Will always return the minimum value
+//! - **BLOBHASH** - Will always return `0`
+//! - **PREVRANDAO** - Use a formula similar to Ethereum, e.g. `L2_prevrandao XOR hash(signed(slot_id))`
 
+use alloy_primitives::keccak256;
 use revm::{
+    bytecode::opcode::{
+        BLOBBASEFEE,
+        BLOBHASH,
+        DIFFICULTY,
+    },
     handler::instructions::EthInstructions,
     interpreter::{
         Host,
+        Interpreter,
         InterpreterTypes,
+        interpreter_types::StackTr,
     },
 };
 
@@ -20,6 +33,66 @@ where
     WIRE: InterpreterTypes,
     HOST: Host,
 {
-    unimplemented!()
+    instructions.insert_instruction(BLOBHASH, linea_blob_hash);
+    instructions.insert_instruction(BLOBBASEFEE, linea_blob_basefee);
+    instructions.insert_instruction(DIFFICULTY, linea_difficulty);
+    Ok(())
 }
 
+/// Implements the linea version of the BLOBHASH instruction.
+///
+/// EIP-4844: Shard Blob Transactions - gets the hash of a transaction blob.
+///
+/// On Linea v4, we always return 0.
+pub fn linea_blob_hash<WIRE: InterpreterTypes, HOST: Host>(
+    interpreter: &mut Interpreter<WIRE>,
+    _host: &mut HOST,
+) {
+    // On Linea v4, we always return 0
+    // Pop the index from stack and push 0
+    if let Some(_index) = interpreter.stack.pop() {
+        let _ = interpreter.stack.push(revm::primitives::U256::ZERO);
+    }
+}
+
+/// EIP-7516: BLOBBASEFEE opcode
+///
+/// The linea version of BLOBBASEFEE returns the minimum value
+// FIXME: this is ambigous, we need to clarify what `minimum value means`. returning 0 for now
+pub fn linea_blob_basefee<WIRE: InterpreterTypes, HOST: Host>(
+    interpreter: &mut Interpreter<WIRE>,
+    _host: &mut HOST,
+) {
+    if let Some(_index) = interpreter.stack.pop() {
+        let _ = interpreter.stack.push(revm::primitives::U256::ZERO);
+    }
+}
+
+/// Implements the linea DIFFICULTY/PREVRANDAO instruction.
+///
+/// The key differance between the regular prevrandao opcode and the linea
+/// version is that on linea, we XOR prevrandao with the keccak of the current slot
+// FIXME: hash is ambigous, we need to get clarity if hash as mentioned in docs is
+// keccak or something more zk freindly. also clarify which slot and its type
+pub fn linea_difficulty<WIRE: InterpreterTypes, HOST: Host>(
+    interpreter: &mut Interpreter<WIRE>,
+    host: &mut HOST,
+) {
+    // get the previous blocks prevrandao
+    let prevrandao = host.prevrandao();
+    if prevrandao.is_none() {
+        // if first block/no prevrandao we can just ret 0
+        let _ = interpreter.stack.push(revm::primitives::U256::ZERO);
+    }
+
+    // get the slot number
+    let slot: i64 = host.block_number().try_into().unwrap();
+    // keccak the slot
+    let hashed_slot = keccak256(slot.to_be_bytes());
+    // now xor them
+    let linea_prevrandao = prevrandao.unwrap().bitxor(hashed_slot.into());
+
+    if let Some(_index) = interpreter.stack.pop() {
+        let _ = interpreter.stack.push(linea_prevrandao);
+    }
+}

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -111,8 +111,7 @@ mod tests {
             assert_eq!(
                 interpreter.stack.peek(0).unwrap(),
                 U256::ZERO,
-                "Index {} should return 0",
-                index
+                "Index {index} should return 0"
             );
         }
     }

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -28,7 +28,7 @@ use revm::{
 // FIXME: this is ideally implemented as an instructionprovider but this is easier
 pub fn insert_linea_instructions<WIRE, HOST>(
     instructions: &mut EthInstructions<WIRE, HOST>,
-) -> Result<(), ()>
+) -> ()
 where
     WIRE: InterpreterTypes,
     HOST: Host,
@@ -36,7 +36,6 @@ where
     instructions.insert_instruction(BLOBHASH, linea_blob_hash);
     instructions.insert_instruction(BLOBBASEFEE, linea_blob_basefee);
     instructions.insert_instruction(DIFFICULTY, linea_difficulty);
-    Ok(())
 }
 
 /// Implements the linea version of the BLOBHASH instruction.
@@ -58,13 +57,13 @@ pub fn linea_blob_hash<WIRE: InterpreterTypes, HOST: Host>(
 /// EIP-7516: BLOBBASEFEE opcode
 ///
 /// The linea version of BLOBBASEFEE returns the minimum value
-// FIXME: this is ambigous, we need to clarify what `minimum value means`. returning 0 for now
+// FIXME: this is ambigous, we need to clarify what `minimum value means`. returning blob_gasprice for now
 pub fn linea_blob_basefee<WIRE: InterpreterTypes, HOST: Host>(
     interpreter: &mut Interpreter<WIRE>,
-    _host: &mut HOST,
+    host: &mut HOST,
 ) {
     if let Some(_index) = interpreter.stack.pop() {
-        let _ = interpreter.stack.push(revm::primitives::U256::ZERO);
+        let _ = interpreter.stack.push(host.blob_gasprice());
     }
 }
 

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -23,6 +23,9 @@ use crate::{
     inspectors::{
         CallTracer,
         PhEvmInspector,
+        TRIGGER_RECORDER,
+        TriggerRecorder,
+        inspector_result_to_call_outcome,
     },
     primitives::bytes,
 };
@@ -205,6 +208,28 @@ impl<ExtDb: DatabaseRef + Clone + DatabaseCommit> Inspector<LineaCtx<'_, MultiFo
                 inputs.return_memory_offset.clone(),
             );
             return Some(call_outcome);
+        }
+
+        // Then check for Linea-specific precompile behavior
+        execute_linea_precompile(context, inputs)
+    }
+}
+
+impl<DB: Database> Inspector<LineaCtx<'_, DB>> for TriggerRecorder {
+    fn call(
+        &mut self,
+        context: &mut LineaCtx<'_, DB>,
+        inputs: &mut CallInputs,
+    ) -> Option<CallOutcome> {
+        if inputs.target_address == TRIGGER_RECORDER {
+            let input_bytes = inputs.input.bytes(context);
+            let record_result = self.record_trigger(&input_bytes);
+            let gas = Gas::new(inputs.gas_limit);
+            return Some(inspector_result_to_call_outcome(
+                record_result,
+                gas,
+                inputs.return_memory_offset.clone(),
+            ));
         }
 
         // Then check for Linea-specific precompile behavior

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -1,0 +1,13 @@
+//! # Linea `precompiles`
+//! 
+//! Contains linea specific precompile implementations.
+//!
+//! Linea v4 implements the osaka spec precompiles with the following differences
+//! - **BLAKE2f** - Compression function F used in the BLAKE2 cryptographic hashing algorithm - Not supported
+//! - **MODEXP** - Arbitrary-precision exponentiation under modulo - Only supports arguments (base, exponent, modulus) that do not exceed 512-byte integers
+//! - **Precompiles as transaction recipients** - Applicable to various use cases - Not supported. A transaction to address cannot be a precompile, i.e. an address in the range 0x01-0x09
+//! - **RIPEMD-160** - A hash function - TBD (treat as removed)
+//!
+//! Instead of actually implementing custom precompiles, we extend the phevm insperctor
+//! impl function to check if we are calling any of the precompiles above. If we are,
+//! we need to process them according to the linea spec.

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -43,20 +43,6 @@ use revm::{
     },
 };
 
-/// `WrappedInspector` exists as a wrapper for merging the functionality of multiple
-/// revm inspectors into one.
-///
-/// This struct fully implements the inspector traits, and when we begin inspection,
-/// we first call into `INSP0`, and then `INSP1`.
-///
-/// This struct is primarily used to Wrap the phevm inspector, providing
-#[derive(Debug)]
-#[allow(dead_code)]
-struct WrappedInspector<INSP0, INSP1> {
-    inspector_0: INSP0,
-    inspector_1: INSP1,
-}
-
 /// Called inside of an inspector to act as if we were calling into
 /// linea precompiles.
 ///

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -55,7 +55,7 @@ struct WrappedInspector<INSP0, INSP1> {
 /// The outcomes depending on the precompile are as follows:
 /// - **BLAKE2f** - Always revert
 /// - **MODEXP** - None (meaning pass) if args (base, exponent, modulus) are individually less than 512 bytes, otherwise revert
-/// - **Precompiles as transaction recipients** - Always revert
+/// - **Precompiles as transaction recipients** - N/A here, FIXME: this should be handled elsewhere as we cannot revert before we execute a call within an inspector.
 /// - **RIPEMD-160** - Always revert
 /// - Anything else - None (meaning pass)
 pub fn execute_linea_precompile<DB: revm::Database>(

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -11,3 +11,31 @@
 //! Instead of actually implementing custom precompiles, we extend the phevm insperctor
 //! impl function to check if we are calling any of the precompiles above. If we are,
 //! we need to process them according to the linea spec.
+
+use revm::{interpreter::CallOutcome, Context};
+
+/// `WrappedInspector` exists as a wrapper for merging the functionality of multiple 
+/// revm inspectors into one.
+///
+/// This struct fully implements the inspector traits, and when we begin inspection,
+/// we first call into `INSP0`, and then `INSP1`.
+///
+/// This struct is primarily used to Wrap the phevm inspector, providing 
+#[derive(Debug)]
+#[allow(dead_code)]
+struct WrappedInspector<INSP0, INSP1> {
+    inspector_0: INSP0,
+    inspector_1: INSP1,
+}
+
+/// Called inside of an inspector to act as if we were calling into
+/// linea precompiles.
+///
+/// The outcomes depending on the precompile are as follows:
+/// - **BLAKE2f** - Always revert
+/// - **MODEXP** - None if args (base, exponent, modulus) are individually less than 512 bytes, otherwise revert
+/// - **Precompiles as transaction recipients** - Always revert
+/// - **RIPEMD-160** - Always revert
+pub fn execute_linea_precompile(ctx: Context) -> Option<CallOutcome> {
+    unimplemented!()
+}

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -1,5 +1,5 @@
 //! # Linea `precompiles`
-//! 
+//!
 //! Contains linea specific precompile implementations.
 //!
 //! Linea v4 implements the osaka spec precompiles with the following differences
@@ -12,15 +12,28 @@
 //! impl function to check if we are calling any of the precompiles above. If we are,
 //! we need to process them according to the linea spec.
 
-use revm::{interpreter::CallOutcome, Context};
+use crate::{
+    db::Database,
+    evm::linea::evm::LineaCtx,
+    inspectors::CallTracer,
+};
+use revm::{
+    Inspector,
+    interpreter::{
+        CallInputs,
+        CallOutcome,
+        CreateInputs,
+        CreateOutcome,
+    },
+};
 
-/// `WrappedInspector` exists as a wrapper for merging the functionality of multiple 
+/// `WrappedInspector` exists as a wrapper for merging the functionality of multiple
 /// revm inspectors into one.
 ///
 /// This struct fully implements the inspector traits, and when we begin inspection,
 /// we first call into `INSP0`, and then `INSP1`.
 ///
-/// This struct is primarily used to Wrap the phevm inspector, providing 
+/// This struct is primarily used to Wrap the phevm inspector, providing
 #[derive(Debug)]
 #[allow(dead_code)]
 struct WrappedInspector<INSP0, INSP1> {
@@ -33,9 +46,47 @@ struct WrappedInspector<INSP0, INSP1> {
 ///
 /// The outcomes depending on the precompile are as follows:
 /// - **BLAKE2f** - Always revert
-/// - **MODEXP** - None if args (base, exponent, modulus) are individually less than 512 bytes, otherwise revert
+/// - **MODEXP** - None (meaning pass) if args (base, exponent, modulus) are individually less than 512 bytes, otherwise revert
 /// - **Precompiles as transaction recipients** - Always revert
 /// - **RIPEMD-160** - Always revert
-pub fn execute_linea_precompile(ctx: Context) -> Option<CallOutcome> {
+/// - Anything else - None (meaning pass)
+pub fn execute_linea_precompile<DB: revm::Database>(
+    ctx: &mut LineaCtx<'_, DB>,
+) -> Option<CallOutcome> {
     unimplemented!()
+}
+
+// Manually implemented for linea
+impl<DB: Database> Inspector<LineaCtx<'_, DB>> for CallTracer {
+    fn call(
+        &mut self,
+        context: &mut LineaCtx<'_, DB>,
+        inputs: &mut CallInputs,
+    ) -> Option<CallOutcome> {
+        let input_bytes = inputs.input.bytes(context);
+        self.record_call_start(
+            inputs.clone(),
+            &input_bytes,
+            &mut context.journaled_state.inner,
+        );
+
+        execute_linea_precompile(context)
+    }
+    fn call_end(
+        &mut self,
+        context: &mut LineaCtx<'_, DB>,
+        _inputs: &CallInputs,
+        _outcome: &mut CallOutcome,
+    ) {
+        self.journal = context.journaled_state.clone();
+        self.record_call_end(&mut context.journaled_state.inner);
+    }
+    fn create_end(
+        &mut self,
+        context: &mut LineaCtx<'_, DB>,
+        _inputs: &CreateInputs,
+        _outcome: &mut CreateOutcome,
+    ) {
+        self.journal = context.journaled_state.clone();
+    }
 }

--- a/crates/assertion-executor/src/evm/macros.rs
+++ b/crates/assertion-executor/src/evm/macros.rs
@@ -1,0 +1,108 @@
+/// Macro to build the appropriate EVM based on feature flags.
+///
+/// This macro handles the complex cfg selects for different EVM types:
+/// - Linea EVM when `linea` feature is enabled
+/// - Optimism EVM when `optimism` feature is enabled (but not `linea`)
+/// - Ethereum mainnet EVM as default
+///
+/// # Arguments
+/// * `$db` - Database reference
+/// * `$env` - EVM environment reference
+/// * `$inspector` - Inspector instance
+///
+/// # Returns
+/// Returns the constructed EVM instance
+///
+/// # Example
+/// ```rust
+/// let mut evm = build_evm_by_features!(&mut db, &env, inspector);
+/// ```
+#[macro_export]
+macro_rules! build_evm_by_features {
+    ($db:expr, $env:expr, $inspector:expr) => {{
+        // ensure only one EVM feature is enabled
+        #[cfg(all(feature = "linea", feature = "optimism"))]
+        compile_error!("Cannot enable both 'linea' and 'optimism' features simultaneously. Please enable only one EVM feature at a time.");
+
+        #[cfg(feature = "linea")]
+        {
+            $crate::evm::linea::build_linea_evm($db, $env, $inspector)
+        }
+
+        #[cfg(all(feature = "optimism", not(feature = "linea")))]
+        {
+            $crate::evm::build_evm::build_optimism_evm($db, $env, $inspector)
+        }
+
+        #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
+        {
+            $crate::evm::build_evm::build_eth_evm($db, $env, $inspector)
+        }
+    }};
+}
+
+/// Macro to conditionally wrap a TxEnv for Optimism if needed.
+///
+/// This macro either returns the original TxEnv unchanged, or wraps it in
+/// `OpTransaction::new()` if the optimism feature is enabled.
+///
+/// # Arguments
+/// * `$tx_env` - The transaction environment to potentially wrap
+///
+/// # Returns
+/// Returns either the original TxEnv or OpTransaction::new(TxEnv) for Optimism
+///
+/// # Example
+/// ```rust
+/// let tx_env = wrap_tx_env_for_optimism!(tx_env);
+/// ```
+#[macro_export]
+macro_rules! wrap_tx_env_for_optimism {
+    ($tx_env:expr) => {{
+        // ensure only one EVM feature is enabled
+        #[cfg(all(feature = "linea", feature = "optimism"))]
+        compile_error!("Cannot enable both 'linea' and 'optimism' features simultaneously. Please enable only one EVM feature at a time.");
+
+        #[cfg(all(feature = "optimism", not(feature = "linea")))]
+        {
+            op_revm::OpTransaction::new($tx_env)
+        }
+
+        #[cfg(any(feature = "linea", not(feature = "optimism")))]
+        {
+            $tx_env
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        evm::build_evm::evm_env,
+        inspectors::CallTracer,
+        primitives::{
+            BlockEnv,
+            SpecId,
+            TxEnv,
+        },
+    };
+    use revm::database::InMemoryDB;
+
+    #[test]
+    fn test_build_evm_by_features_compiles() {
+        let mut db = InMemoryDB::default();
+        let env = evm_env(1, SpecId::default(), BlockEnv::default());
+        let inspector = CallTracer::default();
+
+        // This should compile for any feature combination
+        let _evm = build_evm_by_features!(&mut db, &env, inspector);
+    }
+
+    #[test]
+    fn test_wrap_tx_env_for_optimism_compiles() {
+        let tx_env = TxEnv::default();
+
+        // This should compile for any feature combination
+        let _wrapped_tx = wrap_tx_env_for_optimism!(tx_env);
+    }
+}

--- a/crates/assertion-executor/src/evm/mod.rs
+++ b/crates/assertion-executor/src/evm/mod.rs
@@ -1,3 +1,4 @@
 //pub mod either_evm;
 pub mod build_evm;
 pub mod linea;
+pub mod macros;

--- a/crates/assertion-executor/src/evm/mod.rs
+++ b/crates/assertion-executor/src/evm/mod.rs
@@ -1,2 +1,3 @@
 //pub mod either_evm;
 pub mod build_evm;
+pub mod linea;

--- a/crates/assertion-executor/src/inspectors/mod.rs
+++ b/crates/assertion-executor/src/inspectors/mod.rs
@@ -39,7 +39,7 @@ use std::ops::Range;
 
 /// Convert a result to a call outcome.
 /// Uses the default require [`Error`] signature for encoding revert messages.
-fn inspector_result_to_call_outcome<E: std::fmt::Display>(
+pub fn inspector_result_to_call_outcome<E: std::fmt::Display>(
     result: Result<Bytes, E>,
     gas: Gas,
     memory_offset: Range<usize>,

--- a/crates/assertion-executor/src/inspectors/mod.rs
+++ b/crates/assertion-executor/src/inspectors/mod.rs
@@ -15,6 +15,7 @@ pub use tracer::{
     CallTracerError,
 };
 pub use trigger_recorder::{
+    TRIGGER_RECORDER,
     TriggerRecorder,
     TriggerType,
     insert_trigger_recorder_account,

--- a/crates/assertion-executor/src/inspectors/trigger_recorder.rs
+++ b/crates/assertion-executor/src/inspectors/trigger_recorder.rs
@@ -80,7 +80,7 @@ pub enum RecordError {
 
 impl TriggerRecorder {
     /// Records a trigger call made to the trigger recorder address.
-    fn record_trigger(&mut self, input_bytes: &[u8]) -> Result<Bytes, RecordError> {
+    pub fn record_trigger(&mut self, input_bytes: &[u8]) -> Result<Bytes, RecordError> {
         match input_bytes
             .get(0..4)
             .unwrap_or_default()

--- a/crates/assertion-executor/tests/common/mod.rs
+++ b/crates/assertion-executor/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod harness;
 pub mod test_ctx;
 pub mod tx_utils;

--- a/crates/assertion-executor/tests/indexer_int_tests.rs
+++ b/crates/assertion-executor/tests/indexer_int_tests.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 mod common;
 
 #[cfg(test)]

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -31,7 +31,9 @@ assertion-da-client = { workspace = true }
 alloy-provider = { workspace = true }
 
 [features]
-testing = ["ctor"]
+default = [ "linea" ]
+linea = []
+testing = [ "ctor" ]
 
 [dev-dependencies]
 ctor = "0.5.0"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -13,7 +13,7 @@ dashmap = { workspace = true }
 revm = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-assertion-executor = { workspace = true, features = ["test"] }
+assertion-executor = { workspace = true, default-features = false, features = ["test", "linea"] }
 rust-tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -199,7 +199,6 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
             "Validating transaction against assertions"
         );
 
-
         #[cfg(feature = "linea")]
         if check_recepient_address(&tx_env).is_none() {
             // if `None`, we can just skip this transaction as it failed

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -199,6 +199,14 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
             "Validating transaction against assertions"
         );
 
+
+        #[cfg(feature = "linea")]
+        if check_recepient_address(&tx_env).is_none() {
+            // if `None`, we can just skip this transaction as it failed
+            // linea execution requirements
+            return Ok(());
+        }
+
         // Validate transaction and run assertions
         let rax = match self.assertion_executor.validate_transaction_ext_db(
             block_env.clone(),
@@ -438,6 +446,30 @@ impl<DB: DatabaseRef + Send + Sync> CoreEngine<DB> {
             }
         }
     }
+}
+
+/// This is a linea specific function that checks that transaction recepients
+/// are not precompiles, or fall in the reserved address range of `0x01`-`0x09`.
+///
+/// We call this function on txenvs before we execute them, and return a `None`
+/// if the recepient falls on this address range.
+#[cfg(feature = "linea")]
+fn check_recepient_address(tx: &TxEnv) -> Option<()> {
+    // tx is create, not calling range
+    if tx.kind.is_create() {
+        return Some(());
+    }
+
+    let address = tx.kind.to().unwrap().0;
+    let is_precompile_range = address[0..19] == [0; 19] && (1..=9).contains(&address[19]);
+
+    // Not in the bad precompile range, return some
+    if !is_precompile_range {
+        return Some(());
+    }
+
+    // Bad precompile range, return none
+    None
 }
 
 #[cfg(test)]

--- a/crates/sidecar/src/engine/transactions_results.rs
+++ b/crates/sidecar/src/engine/transactions_results.rs
@@ -162,7 +162,7 @@ mod tests {
             let result = if i % 2 == 0 {
                 create_test_result_success()
             } else {
-                create_test_result_error(&format!("error {}", i))
+                create_test_result_error(&format!("error {i}"))
             };
             results.add_transaction_result(tx_hash, result);
         }
@@ -283,7 +283,7 @@ mod tests {
         for i in 1..=10 {
             let tx_hash = create_test_tx_hash(i);
             tx_hashes.push(tx_hash);
-            let result = create_test_result_error(&format!("error {}", i));
+            let result = create_test_result_error(&format!("error {i}"));
             results.add_transaction_result(tx_hash, result);
         }
 


### PR DESCRIPTION
- Implements `LineaEvm` and `LineaCtx`, which are used to construct an evm that includes linea specific opcode behavior
- Implements linea behavior for precompiles via inspectors.
- Implements precompile behavior by extending `CallTracer` and `PhEvmInspector` inspectors with the `execute_linea_precompile` function
- `execute_linea_precompile` conditionally does nothing or returns a specific `CallResult` error if an error condition for a precompile is met