### PR TITLE
feat(sidecar): unify config arguments for consistency

### DIFF
--- a/crates/sidecar/src/args/mod.rs
+++ b/crates/sidecar/src/args/mod.rs
@@ -36,14 +36,18 @@ pub const DEFAULT_STATE_ORACLE_ADDRESS: &str = "0x6dD3f12ce435f69DCeDA7e31605C02
 pub struct ChainArgs {
     /// chain block time in milliseconds
     #[arg(
-        long = "chain.chain-block-time",
+        long = "chain.block-time",
         default_value = "1000",
         env = "CHAIN_BLOCK_TIME"
     )]
-    pub chain_block_time: u64,
+    pub block_time: u64,
 
     /// How much time extra to wait for the block building job to complete and not get garbage collected
-    #[arg(long = "chain.extra-block-deadline-secs", default_value = "20")]
+    #[arg(
+        long = "chain.extra-block-deadline-secs",
+        default_value = "20",
+        env = "CHAIN_EXTRA_BLOCK_DEADLINE_SECS"
+    )]
     pub extra_block_deadline_secs: u64,
 
     /// What EVM specification to use. Only latest for now
@@ -55,9 +59,9 @@ pub struct ChainArgs {
     )]
     pub spec_id: SpecIdArg,
 
-    /// Transport JSON-RPC server URL and port
+    /// RPC node URL and port
     #[arg(
-        long = "chain.transport-url",
+        long = "chain.rpc-url",
         default_value = "http://127.0.0.1:8545",
         env = "CHAIN_RPC_URL"
     )]
@@ -70,7 +74,7 @@ pub struct TelemetryArgs {
     /// Inverted sampling frequency in blocks. 1 - each block, 100 - every 100th block.
     #[arg(
         long = "telemetry.sampling-ratio",
-        env = "SAMPLING_RATIO",
+        env = "TELEMETRY_SAMPLING_RATIO",
         default_value = "100"
     )]
     pub sampling_ratio: u64,
@@ -81,84 +85,88 @@ pub struct TelemetryArgs {
 pub struct CredibleArgs {
     /// Soft timeout for credible block building in milliseconds
     #[arg(
-        long = "ae.soft-timeout-ms",
+        long = "credible.soft-timeout-ms",
         default_value = "650",
-        env = "AE_BLOCK_TIME_LIMIT"
+        env = "CREDIBLE_SOFT_TIMEOUT_MS"
     )]
     pub soft_timeout_ms: u64,
 
     /// Gas limit for assertion execution
     #[arg(
-        long = "ae.assertion-gas-limit",
+        long = "credible.assertion-gas-limit",
         default_value = "3000000",
-        env = "AE_ASSERTION_GAS_LIMIT"
+        env = "CREDIBLE_ASSERTION_GAS_LIMIT"
     )]
     pub assertion_gas_limit: u64,
 
     /// Overlay cache capacity, 1gb default
     #[arg(
-        long = "ae.overlay_cache_capacity_bytes",
+        long = "credible.overlay-cache-capacity-bytes",
         default_value = "1024000000",
-        env = "AE_CACHE_CAPACITY_BYTES"
+        env = "CREDIBLE_OVERLAY_CACHE_CAPACITY_BYTES"
     )]
     pub overlay_cache_capacity_bytes: Option<usize>,
 
     /// Path to the `assertion-executor` database.
-    #[arg(long = "ae.db_path", default_value = "ae_database", env = "AE_DB_PATH")]
+    #[arg(
+        long = "credible.db-path",
+        default_value = "ae_database",
+        env = "CREDIBLE_DB_PATH"
+    )]
     pub db_path: PathBuf,
 
     /// Sled cache capacity, used in the `FsDb`, 256mb default
     #[arg(
-        long = "ae.cache_capacity_bytes",
+        long = "credible.cache-capacity-bytes",
         default_value = "256000000",
-        env = "AE_CACHE_CAPACITY_BYTES"
+        env = "CREDIBLE_CACHE_CAPACITY_BYTES"
     )]
     pub cache_capacity_bytes: Option<usize>,
 
     /// How often in ms will the `FsDb` be flushed to disk, 5 sec default
     #[arg(
-        long = "ae.flush_every_ms",
+        long = "credible.flush-every-ms",
         default_value = "5000",
-        env = "AE_FLUSH_EVERY_MS"
+        env = "CREDIBLE_FLUSH_EVERY_MS"
     )]
     pub flush_every_ms: Option<usize>,
 
     /// `FsDb` compression level, default to 3
     #[arg(
-        long = "ae.fs_compression_level",
+        long = "credible.zstd-compression-level",
         default_value = "3",
-        env = "AE_FS_COMPRESSION_LEVEL"
+        env = "CREDIBLE_ZSTD_COMPRESSION_LEVEL"
     )]
     pub zstd_compression_level: Option<i32>,
 
     /// WS URL the RPC store will use to index assertions
     #[arg(
-        long = "ae.rpc_url",
+        long = "credible.indexer-rpc-url",
         default_value = "ws://localhost:8546",
-        env = "AE_RPC_STORE_URL"
+        env = "CREDIBLE_INDEXER_RPC_URL"
     )]
-    pub indexer_rpc: String,
+    pub indexer_rpc_url: String,
 
     /// HTTP URL of the assertion DA
     #[arg(
-        long = "ae.rpc_da_url",
+        long = "credible.rpc-da-url",
         default_value = "http://localhost:5001",
-        env = "AE_RPC_DA_URL"
+        env = "CREDIBLE_RPC_DA_URL"
     )]
     pub rpc_da_url: String,
 
     /// Path to the rpc store db
     #[arg(
-        long = "ae.rpc_store_db_path",
+        long = "credible.rpc-store-db-path",
         default_value = "rpc_store_database",
-        env = "AE_RPC_STORE_DB_PATH"
+        env = "CREDIBLE_RPC_STORE_DB_PATH"
     )]
-    pub rpc_store_db: PathBuf,
+    pub rpc_store_db_path: PathBuf,
 
     /// Block tag to use for indexing assertions.
     #[arg(
-        long = "ae.block_tag",
-        env = "AE_BLOCK_TAG",
+        long = "credible.block-tag",
+        env = "CREDIBLE_BLOCK_TAG",
         default_value = "finalized",
         value_enum
     )]
@@ -166,25 +174,25 @@ pub struct CredibleArgs {
 
     /// Contract address of the state oracle contract, used to query assertion info
     #[arg(
-        long = "ae.oracle_contract",
+        long = "credible.oracle-contract",
         default_value = DEFAULT_STATE_ORACLE_ADDRESS,
-        env = "AE_ORACLE_CONTRACT",
+        env = "CREDIBLE_ORACLE_CONTRACT",
         required = true
     )]
     pub oracle_contract: Address,
 
     /// Path to the indexer database (separate from main assertion store)
     #[arg(
-        long = "ae.indexer_db_path",
+        long = "credible.indexer-db-path",
         default_value = "indexer_database",
-        env = "AE_INDEXER_DB_PATH"
+        env = "CREDIBLE_INDEXER_DB_PATH"
     )]
     pub indexer_db_path: PathBuf,
 
     #[arg(
-        long = "ae.transaction_results_max_capacity",
+        long = "credible.transaction-results-max-capacity",
         default_value = "1000000",
-        env = "AE_TRANSACTION_RESULTS_MAX_CAPACITY"
+        env = "CREDIBLE_TRANSACTION_RESULTS_MAX_CAPACITY"
     )]
     pub transaction_results_max_capacity: usize,
 }
@@ -193,19 +201,11 @@ pub struct CredibleArgs {
 pub struct HttpTransportArgs {
     /// Server bind address and port
     #[arg(
-        long = "ae.bind-addr",
+        long = "transport.bind-addr",
         default_value = "127.0.0.1:8080",
-        env = "AE_BIND_ADDR"
+        env = "TRANSPORT_BIND_ADDR"
     )]
     pub bind_addr: String,
-
-    /// Server bind address and port
-    #[arg(
-        long = "ae.driver-addr",
-        default_value = "127.0.0.1:1337",
-        env = "AE_DRIVER_ADDR"
-    )]
-    pub driver_addr: String,
 }
 
 /// Main sidecar arguments that extend TelemetryArgs and CredibleArgs
@@ -219,7 +219,7 @@ pub struct SidecarArgs {
     pub credible: CredibleArgs,
 
     #[command(flatten)]
-    pub rollup: ChainArgs,
+    pub chain: ChainArgs,
 
     #[command(flatten)]
     pub transport: HttpTransportArgs,

--- a/crates/sidecar/src/args/mod.rs
+++ b/crates/sidecar/src/args/mod.rs
@@ -109,11 +109,11 @@ pub struct CredibleArgs {
 
     /// Path to the `assertion-executor` database.
     #[arg(
-        long = "credible.db-path",
+        long = "credible.assertion-executor-db-path",
         default_value = "ae_database",
-        env = "CREDIBLE_DB_PATH"
+        env = "CREDIBLE_ASSERTION_EXECUTOR_DB_PATH"
     )]
-    pub db_path: PathBuf,
+    pub assertion_executor_db_path: PathBuf,
 
     /// Sled cache capacity, used in the `FsDb`, 256mb default
     #[arg(
@@ -149,19 +149,19 @@ pub struct CredibleArgs {
 
     /// HTTP URL of the assertion DA
     #[arg(
-        long = "credible.rpc-da-url",
+        long = "credible.assertion-da-rpc-url",
         default_value = "http://localhost:5001",
-        env = "CREDIBLE_RPC_DA_URL"
+        env = "CREDIBLE_ASSERTION_DA_RPC_URL"
     )]
-    pub rpc_da_url: String,
+    pub assertion_da_rpc_url: String,
 
     /// Path to the rpc store db
     #[arg(
-        long = "credible.rpc-store-db-path",
-        default_value = "rpc_store_database",
-        env = "CREDIBLE_RPC_STORE_DB_PATH"
+        long = "credible.assertion-store-db-path",
+        default_value = "assertion_store_database",
+        env = "CREDIBLE_ASSERTION_STORE_DB_PATH"
     )]
-    pub rpc_store_db_path: PathBuf,
+    pub assertion_store_db_path: PathBuf,
 
     /// Block tag to use for indexing assertions.
     #[arg(
@@ -174,12 +174,12 @@ pub struct CredibleArgs {
 
     /// Contract address of the state oracle contract, used to query assertion info
     #[arg(
-        long = "credible.oracle-contract",
+        long = "credible.state-oracle",
         default_value = DEFAULT_STATE_ORACLE_ADDRESS,
-        env = "CREDIBLE_ORACLE_CONTRACT",
+        env = "CREDIBLE_STATE_ORACLE",
         required = true
     )]
-    pub oracle_contract: Address,
+    pub state_oracle: Address,
 
     /// Path to the indexer database (separate from main assertion store)
     #[arg(

--- a/crates/sidecar/src/config.rs
+++ b/crates/sidecar/src/config.rs
@@ -39,7 +39,7 @@ pub fn init_executor_config(args: &SidecarArgs) -> ExecutorConfig {
 /// Initialize AssertionStore from SidecarArgs
 pub fn init_assertion_store(args: &SidecarArgs) -> Result<AssertionStore, AssertionStoreError> {
     let mut db_config = sled::Config::new();
-    db_config = db_config.path(&args.credible.db_path);
+    db_config = db_config.path(&args.credible.assertion_executor_db_path);
 
     if let Some(cache_capacity) = args.credible.cache_capacity_bytes {
         db_config = db_config.cache_capacity_bytes(cache_capacity);
@@ -52,7 +52,7 @@ pub fn init_assertion_store(args: &SidecarArgs) -> Result<AssertionStore, Assert
     let db = db_config.open()?;
 
     info!(
-        db_path = ?args.credible.db_path,
+        db_path = ?args.credible.assertion_executor_db_path,
         cache_capacity = ?args.credible.cache_capacity_bytes,
         flush_every_ms = ?args.credible.flush_every_ms,
         "Initialized persistent AssertionStore"
@@ -68,7 +68,7 @@ pub async fn init_indexer_config(
     executor_config: ExecutorConfig,
 ) -> anyhow::Result<IndexerCfg> {
     // Initialize DA client
-    let da_client = DaClient::new(&args.credible.rpc_da_url)?;
+    let da_client = DaClient::new(&args.credible.assertion_da_rpc_url)?;
 
     // Initialize provider for blockchain connection
     let ws_connect = WsConnect::new(&args.credible.indexer_rpc_url);
@@ -90,8 +90,8 @@ pub async fn init_indexer_config(
     let indexer_db = indexer_db_config.open()?;
 
     debug!(
-        state_oracle = ?args.credible.oracle_contract,
-        da_url = ?args.credible.rpc_da_url,
+        state_oracle = ?args.credible.state_oracle,
+        da_url = ?args.credible.assertion_da_rpc_url,
         indexer_rpc = ?args.credible.indexer_rpc_url,
         indexer_db_path = ?args.credible.indexer_db_path,
         block_tag = ?args.credible.block_tag,
@@ -99,7 +99,7 @@ pub async fn init_indexer_config(
     );
 
     Ok(IndexerCfg {
-        state_oracle: args.credible.oracle_contract,
+        state_oracle: args.credible.state_oracle,
         da_client,
         executor_config,
         store,

--- a/crates/sidecar/src/config.rs
+++ b/crates/sidecar/src/config.rs
@@ -23,7 +23,7 @@ use tracing::{
 /// Initialize ExecutorConfig from SidecarArgs
 pub fn init_executor_config(args: &SidecarArgs) -> ExecutorConfig {
     let config = ExecutorConfig::default()
-        .with_spec_id(args.rollup.spec_id.clone().into())
+        .with_spec_id(args.chain.spec_id.clone().into())
         .with_assertion_gas_limit(args.credible.assertion_gas_limit);
 
     debug!(
@@ -71,7 +71,7 @@ pub async fn init_indexer_config(
     let da_client = DaClient::new(&args.credible.rpc_da_url)?;
 
     // Initialize provider for blockchain connection
-    let ws_connect = WsConnect::new(&args.credible.indexer_rpc);
+    let ws_connect = WsConnect::new(&args.credible.indexer_rpc_url);
     let provider = ProviderBuilder::new().connect_ws(ws_connect).await?;
     let provider = provider.root().clone();
 
@@ -92,7 +92,7 @@ pub async fn init_indexer_config(
     debug!(
         state_oracle = ?args.credible.oracle_contract,
         da_url = ?args.credible.rpc_da_url,
-        indexer_rpc = ?args.credible.indexer_rpc,
+        indexer_rpc = ?args.credible.indexer_rpc_url,
         indexer_db_path = ?args.credible.indexer_db_path,
         block_tag = ?args.credible.block_tag,
         "Initialized IndexerCfg"

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
     let args = SidecarArgs::parse();
 
     let (tx_sender, tx_receiver) = unbounded();
-    let json_rpc_db = JsonRpcDb::try_new(&args.rollup.rpc_url).await?;
+    let json_rpc_db = JsonRpcDb::try_new(&args.chain.rpc_url).await?;
     let state: OverlayDb<JsonRpcDb> = OverlayDb::new(
         Some(json_rpc_db),
         args.credible


### PR DESCRIPTION
- Unify the config arguments for consistency
- Format:
```
    #[arg(
        long = "TYPE.name",
        default_value = "20",
        env = "TYPE_NAME"
    )]
```