### PR TITLE
[CHAINED] feat: assertion executor configure evm spec to use linea revm

### DIFF
--- a/.github/workflows/rust-test-lint.yml
+++ b/.github/workflows/rust-test-lint.yml
@@ -36,6 +36,6 @@ jobs:
       foundry-command: 'forge build --root testdata/mock-protocol'
       # [""] means default features
       # Feature matrices are supported as follows: ["", "--features=foo", "--features=bar", "--features=foo,bar"]
-      feature-sets: '["", "--no-default-features --features linea", "--no-default-features"]'
+      feature-sets: '["", "--no-default-features --features=linea", "--no-default-features"]'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/rust-test-lint.yml
+++ b/.github/workflows/rust-test-lint.yml
@@ -36,6 +36,6 @@ jobs:
       foundry-command: 'forge build --root testdata/mock-protocol'
       # [""] means default features
       # Feature matrices are supported as follows: ["", "--features=foo", "--features=bar", "--features=foo,bar"]
-      feature-sets: '["", "linea", "--no-default-features"]'
+      feature-sets: '["", "--no-default-features --features linea", "--no-default-features"]'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/rust-test-lint.yml
+++ b/.github/workflows/rust-test-lint.yml
@@ -36,6 +36,6 @@ jobs:
       foundry-command: 'forge build --root testdata/mock-protocol'
       # [""] means default features
       # Feature matrices are supported as follows: ["", "--features=foo", "--features=bar", "--features=foo,bar"]
-      feature-sets: '["", "--no-default-features"]'
+      feature-sets: '["", "linea", "--no-default-features"]'
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ assertion-da-server = { path = "crates/assertion-da/da-server" }
 int-test-utils = { path = "crates/int-test-utils" }
 
 # assertion-executor
-assertion-executor = { path = "crates/assertion-executor" }
+assertion-executor = { path = "crates/assertion-executor",  default-features = false }
 
 anyhow = "1.0.86"
 clap = { version = "4.5.11", features = ["derive", "env"] }

--- a/crates/assertion-executor/Cargo.toml
+++ b/crates/assertion-executor/Cargo.toml
@@ -54,6 +54,7 @@ evm-glue = { workspace = true }
 [features]
 default = ["optimism", "full-test"]
 optimism = []
+linea = []
 phoundry = ["revm/optional_eip3607"]
 test = ["serde_json", "rand"]
 serde_json = []

--- a/crates/assertion-executor/Cargo.toml
+++ b/crates/assertion-executor/Cargo.toml
@@ -52,7 +52,7 @@ evm-glue = { workspace = true }
 
 
 [features]
-default = ["optimism", "full-test"]
+default = ["full-test"]
 optimism = []
 linea = []
 phoundry = ["revm/optional_eip3607"]
@@ -69,7 +69,7 @@ assertion-da-server = { workspace = true }
 criterion = { workspace = true }
 bollard = { workspace = true }
 int-test-utils = { workspace = true }
-assertion-executor = { path = ".", features = ["test"] }
+assertion-executor = { path = ".", default-features = false, features = ["test"] }
 futures = { workspace = true }
 anyhow = { workspace = true }
 evm-glue = { workspace = true }

--- a/crates/assertion-executor/src/evm/build_evm.rs
+++ b/crates/assertion-executor/src/evm/build_evm.rs
@@ -299,7 +299,15 @@ mod tests {
 
         let inspector = PhEvmInspector::new(phvem_context);
 
-        #[cfg(feature = "optimism")]
+        #[cfg(feature = "linea")]
+        let (mut evm, tx_env) = {
+            let env = evm_env(1, SpecId::default(), BlockEnv::default());
+            (
+                crate::evm::linea::build_linea_evm(&mut multi_fork_db, &env, inspector),
+                tx_env,
+            )
+        };
+        #[cfg(all(feature = "optimism", not(feature = "linea")))]
         let (mut evm, tx_env) = {
             let env = evm_env(1, SpecId::default(), BlockEnv::default());
             (
@@ -307,10 +315,13 @@ mod tests {
                 OpTransaction::new(tx_env),
             )
         };
-        #[cfg(not(feature = "optimism"))]
-        let mut evm = {
+        #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
+        let (mut evm, tx_env) = {
             let env = evm_env(1, SpecId::default(), BlockEnv::default());
-            build_eth_evm(&mut multi_fork_db, &env, inspector)
+            (
+                build_eth_evm(&mut multi_fork_db, &env, inspector),
+                tx_env,
+            )
         };
 
         if with_reprice {

--- a/crates/assertion-executor/src/evm/build_evm.rs
+++ b/crates/assertion-executor/src/evm/build_evm.rs
@@ -318,10 +318,7 @@ mod tests {
         #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
         let (mut evm, tx_env) = {
             let env = evm_env(1, SpecId::default(), BlockEnv::default());
-            (
-                build_eth_evm(&mut multi_fork_db, &env, inspector),
-                tx_env,
-            )
+            (build_eth_evm(&mut multi_fork_db, &env, inspector), tx_env)
         };
 
         if with_reprice {

--- a/crates/assertion-executor/src/evm/linea/evm.rs
+++ b/crates/assertion-executor/src/evm/linea/evm.rs
@@ -60,7 +60,7 @@ type LineaEvmTyped<'db, DB, I> = Evm<LineaCtx<'db, DB>, I, LineaIns<'db, DB>, Et
 /// # IMPORTANT: tracer and precompiles
 /// Linea has some minor precompile changes to precompiles. We have implemented such
 /// changes within an inspector. ***To get full linea precompile changes, you must use
-/// either the `CallTracer` or `PhEvmInspector` inspectors!!!.***
+/// either the `CallTracer`, `TriggerRecorder` or `PhEvmInspector` inspectors!!!.***
 ///
 /// # Executing transactions
 /// To implement our *own* evm we needed to wrap the Linea evm in a struct.
@@ -155,7 +155,8 @@ where
 
 /// Builds a Linea EVM enviroment. Replaces specific opcodes with their linea compatible counterparts.
 ///
-/// ***IMPORTANT:*** To get linea precompile functionality, you must use either the `CallTracer` or `PhEvmInspector` inspectors.
+/// ***IMPORTANT:*** To get linea precompile functionality, you must use either the `CallTracer`,
+/// `TriggerRecorder` or `PhEvmInspector` inspectors.
 ///
 /// The `chain_id` is used to set the chain ID in the EVM environment.
 /// The `spec_id` is used to set the spec ID in the EVM environment.

--- a/crates/assertion-executor/src/evm/linea/opcodes.rs
+++ b/crates/assertion-executor/src/evm/linea/opcodes.rs
@@ -111,8 +111,7 @@ mod tests {
             assert_eq!(
                 interpreter.stack.peek(0).unwrap(),
                 U256::ZERO,
-                "Index {} should return 0",
-                index
+                "Index {index} should return 0"
             );
         }
     }

--- a/crates/assertion-executor/src/evm/linea/precompiles.rs
+++ b/crates/assertion-executor/src/evm/linea/precompiles.rs
@@ -12,8 +12,6 @@
 //! impl function to check if we are calling any of the precompiles above. If we are,
 //! we need to process them according to the linea spec.
 
-use crate::inspectors::{TriggerRecorder, TRIGGER_RECORDER};
-use crate::inspectors::inspector_result_to_call_outcome;
 use crate::{
     db::{
         Database,
@@ -25,6 +23,9 @@ use crate::{
     inspectors::{
         CallTracer,
         PhEvmInspector,
+        TRIGGER_RECORDER,
+        TriggerRecorder,
+        inspector_result_to_call_outcome,
     },
     primitives::bytes,
 };

--- a/crates/assertion-executor/src/evm/macros.rs
+++ b/crates/assertion-executor/src/evm/macros.rs
@@ -1,0 +1,96 @@
+/// Macro to build the appropriate EVM based on feature flags.
+/// 
+/// This macro handles the complex cfg selects for different EVM types:
+/// - Linea EVM when `linea` feature is enabled
+/// - Optimism EVM when `optimism` feature is enabled (but not `linea`)
+/// - Ethereum mainnet EVM as default
+/// 
+/// # Arguments
+/// * `$db` - Database reference
+/// * `$env` - EVM environment reference
+/// * `$inspector` - Inspector instance
+/// 
+/// # Returns
+/// Returns the constructed EVM instance
+/// 
+/// # Example
+/// ```rust
+/// let mut evm = build_evm_by_features!(&mut db, &env, inspector);
+/// ```
+#[macro_export]
+macro_rules! build_evm_by_features {
+    ($db:expr, $env:expr, $inspector:expr) => {{
+        #[cfg(feature = "linea")]
+        {
+            $crate::evm::linea::build_linea_evm($db, $env, $inspector)
+        }
+        
+        #[cfg(all(feature = "optimism", not(feature = "linea")))]
+        {
+            $crate::evm::build_evm::build_optimism_evm($db, $env, $inspector)
+        }
+        
+        #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
+        {
+            $crate::evm::build_evm::build_eth_evm($db, $env, $inspector)
+        }
+    }};
+}
+
+/// Macro to conditionally wrap a TxEnv for Optimism if needed.
+/// 
+/// This macro either returns the original TxEnv unchanged, or wraps it in
+/// `OpTransaction::new()` if the optimism feature is enabled.
+/// 
+/// # Arguments
+/// * `$tx_env` - The transaction environment to potentially wrap
+/// 
+/// # Returns
+/// Returns either the original TxEnv or OpTransaction::new(TxEnv) for Optimism
+/// 
+/// # Example
+/// ```rust
+/// let tx_env = wrap_tx_env_for_optimism!(tx_env);
+/// ```
+#[macro_export]
+macro_rules! wrap_tx_env_for_optimism {
+    ($tx_env:expr) => {{
+        #[cfg(all(feature = "optimism", not(feature = "linea")))]
+        {
+            op_revm::OpTransaction::new($tx_env)
+        }
+        
+        #[cfg(any(feature = "linea", not(feature = "optimism")))]
+        {
+            $tx_env
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        evm::build_evm::evm_env,
+        primitives::{BlockEnv, TxEnv, SpecId},
+        inspectors::CallTracer,
+    };
+    use revm::database::InMemoryDB;
+
+    #[test]
+    fn test_build_evm_by_features_compiles() {
+        let mut db = InMemoryDB::default();
+        let env = evm_env(1, SpecId::default(), BlockEnv::default());
+        let inspector = CallTracer::default();
+        
+        // This should compile for any feature combination
+        let _evm = build_evm_by_features!(&mut db, &env, inspector);
+    }
+
+    #[test]
+    fn test_wrap_tx_env_for_optimism_compiles() {
+        let tx_env = TxEnv::default();
+        
+        // This should compile for any feature combination
+        let _wrapped_tx = wrap_tx_env_for_optimism!(tx_env);
+    }
+}

--- a/crates/assertion-executor/src/evm/macros.rs
+++ b/crates/assertion-executor/src/evm/macros.rs
@@ -4,7 +4,7 @@
 /// - Linea EVM when `linea` feature is enabled
 /// - Optimism EVM when `optimism` feature is enabled (but not `linea`)
 /// - Ethereum mainnet EVM as default
-/// 
+///
 /// # Arguments
 /// * `$db` - Database reference
 /// * `$env` - EVM environment reference
@@ -20,6 +20,10 @@
 #[macro_export]
 macro_rules! build_evm_by_features {
     ($db:expr, $env:expr, $inspector:expr) => {{
+        // ensure only one EVM feature is enabled
+        #[cfg(all(feature = "linea", feature = "optimism"))]
+        compile_error!("Cannot enable both 'linea' and 'optimism' features simultaneously. Please enable only one EVM feature at a time.");
+        
         #[cfg(feature = "linea")]
         {
             $crate::evm::linea::build_linea_evm($db, $env, $inspector)
@@ -41,7 +45,7 @@ macro_rules! build_evm_by_features {
 /// 
 /// This macro either returns the original TxEnv unchanged, or wraps it in
 /// `OpTransaction::new()` if the optimism feature is enabled.
-/// 
+///
 /// # Arguments
 /// * `$tx_env` - The transaction environment to potentially wrap
 /// 
@@ -55,6 +59,10 @@ macro_rules! build_evm_by_features {
 #[macro_export]
 macro_rules! wrap_tx_env_for_optimism {
     ($tx_env:expr) => {{
+        // ensure only one EVM feature is enabled
+        #[cfg(all(feature = "linea", feature = "optimism"))]
+        compile_error!("Cannot enable both 'linea' and 'optimism' features simultaneously. Please enable only one EVM feature at a time.");
+        
         #[cfg(all(feature = "optimism", not(feature = "linea")))]
         {
             op_revm::OpTransaction::new($tx_env)

--- a/crates/assertion-executor/src/evm/macros.rs
+++ b/crates/assertion-executor/src/evm/macros.rs
@@ -1,5 +1,5 @@
 /// Macro to build the appropriate EVM based on feature flags.
-/// 
+///
 /// This macro handles the complex cfg selects for different EVM types:
 /// - Linea EVM when `linea` feature is enabled
 /// - Optimism EVM when `optimism` feature is enabled (but not `linea`)
@@ -9,10 +9,10 @@
 /// * `$db` - Database reference
 /// * `$env` - EVM environment reference
 /// * `$inspector` - Inspector instance
-/// 
+///
 /// # Returns
 /// Returns the constructed EVM instance
-/// 
+///
 /// # Example
 /// ```rust
 /// let mut evm = build_evm_by_features!(&mut db, &env, inspector);
@@ -23,17 +23,17 @@ macro_rules! build_evm_by_features {
         // ensure only one EVM feature is enabled
         #[cfg(all(feature = "linea", feature = "optimism"))]
         compile_error!("Cannot enable both 'linea' and 'optimism' features simultaneously. Please enable only one EVM feature at a time.");
-        
+
         #[cfg(feature = "linea")]
         {
             $crate::evm::linea::build_linea_evm($db, $env, $inspector)
         }
-        
+
         #[cfg(all(feature = "optimism", not(feature = "linea")))]
         {
             $crate::evm::build_evm::build_optimism_evm($db, $env, $inspector)
         }
-        
+
         #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
         {
             $crate::evm::build_evm::build_eth_evm($db, $env, $inspector)
@@ -42,16 +42,16 @@ macro_rules! build_evm_by_features {
 }
 
 /// Macro to conditionally wrap a TxEnv for Optimism if needed.
-/// 
+///
 /// This macro either returns the original TxEnv unchanged, or wraps it in
 /// `OpTransaction::new()` if the optimism feature is enabled.
 ///
 /// # Arguments
 /// * `$tx_env` - The transaction environment to potentially wrap
-/// 
+///
 /// # Returns
 /// Returns either the original TxEnv or OpTransaction::new(TxEnv) for Optimism
-/// 
+///
 /// # Example
 /// ```rust
 /// let tx_env = wrap_tx_env_for_optimism!(tx_env);
@@ -62,12 +62,12 @@ macro_rules! wrap_tx_env_for_optimism {
         // ensure only one EVM feature is enabled
         #[cfg(all(feature = "linea", feature = "optimism"))]
         compile_error!("Cannot enable both 'linea' and 'optimism' features simultaneously. Please enable only one EVM feature at a time.");
-        
+
         #[cfg(all(feature = "optimism", not(feature = "linea")))]
         {
             op_revm::OpTransaction::new($tx_env)
         }
-        
+
         #[cfg(any(feature = "linea", not(feature = "optimism")))]
         {
             $tx_env
@@ -79,8 +79,12 @@ macro_rules! wrap_tx_env_for_optimism {
 mod tests {
     use crate::{
         evm::build_evm::evm_env,
-        primitives::{BlockEnv, TxEnv, SpecId},
         inspectors::CallTracer,
+        primitives::{
+            BlockEnv,
+            SpecId,
+            TxEnv,
+        },
     };
     use revm::database::InMemoryDB;
 
@@ -89,7 +93,7 @@ mod tests {
         let mut db = InMemoryDB::default();
         let env = evm_env(1, SpecId::default(), BlockEnv::default());
         let inspector = CallTracer::default();
-        
+
         // This should compile for any feature combination
         let _evm = build_evm_by_features!(&mut db, &env, inspector);
     }
@@ -97,7 +101,7 @@ mod tests {
     #[test]
     fn test_wrap_tx_env_for_optimism_compiles() {
         let tx_env = TxEnv::default();
-        
+
         // This should compile for any feature combination
         let _wrapped_tx = wrap_tx_env_for_optimism!(tx_env);
     }

--- a/crates/assertion-executor/src/evm/mod.rs
+++ b/crates/assertion-executor/src/evm/mod.rs
@@ -1,3 +1,4 @@
 //pub mod either_evm;
 pub mod build_evm;
 pub mod linea;
+pub mod macros;

--- a/crates/assertion-executor/src/executor/mod.rs
+++ b/crates/assertion-executor/src/executor/mod.rs
@@ -357,18 +357,8 @@ impl AssertionExecutor {
 
         let env = evm_env(self.config.chain_id, self.config.spec_id, block_env.clone());
 
-        #[cfg(feature = "linea")]
-        let mut evm = crate::evm::linea::build_linea_evm(&mut multi_fork_db, &env, inspector);
-        
-        #[cfg(all(feature = "optimism", not(feature = "linea")))]
-        let (mut evm, tx_env) = {
-            let evm =
-                crate::evm::build_evm::build_optimism_evm(&mut multi_fork_db, &env, inspector);
-            (evm, op_revm::OpTransaction::new(tx_env))
-        };
-
-        #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
-        let mut evm = crate::evm::build_evm::build_eth_evm(&mut multi_fork_db, &env, inspector);
+        let mut evm = crate::build_evm_by_features!(&mut multi_fork_db, &env, inspector);
+        let tx_env = crate::wrap_tx_env_for_optimism!(tx_env);
 
         reprice_evm_storage!(evm);
 
@@ -415,24 +405,8 @@ impl AssertionExecutor {
         let mut call_tracer = CallTracer::default();
         let env = evm_env(self.config.chain_id, self.config.spec_id, block_env.clone());
 
-        #[cfg(feature = "linea")]
-        let (mut evm, tx_env) = {
-            let evm = crate::evm::linea::build_linea_evm(external_db, &env, &mut call_tracer);
-            (evm, tx_env)
-        };
-
-        #[cfg(all(feature = "optimism", not(feature = "linea")))]
-        let (mut evm, tx_env) = {
-            let evm =
-                crate::evm::build_evm::build_optimism_evm(external_db, &env, &mut call_tracer);
-            (evm, op_revm::OpTransaction::new(tx_env))
-        };
-
-        #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
-        let (mut evm, tx_env) = {
-            let evm = crate::evm::build_evm::build_eth_evm(external_db, &env, &mut call_tracer);
-            (evm, tx_env)
-        };
+        let mut evm = crate::build_evm_by_features!(external_db, &env, &mut call_tracer);
+        let tx_env = crate::wrap_tx_env_for_optimism!(tx_env);
 
         let result_and_state = evm.inspect_with_tx(tx_env).map_err(|e| {
             debug!(target: "assertion-executor::execute_tx", error = %e, "Evm error in execute_forked_tx");

--- a/crates/assertion-executor/src/inspectors/mod.rs
+++ b/crates/assertion-executor/src/inspectors/mod.rs
@@ -18,6 +18,7 @@ pub use trigger_recorder::{
     TriggerRecorder,
     TriggerType,
     insert_trigger_recorder_account,
+    TRIGGER_RECORDER,
 };
 
 use sol_primitives::Error;

--- a/crates/assertion-executor/src/inspectors/mod.rs
+++ b/crates/assertion-executor/src/inspectors/mod.rs
@@ -15,10 +15,10 @@ pub use tracer::{
     CallTracerError,
 };
 pub use trigger_recorder::{
+    TRIGGER_RECORDER,
     TriggerRecorder,
     TriggerType,
     insert_trigger_recorder_account,
-    TRIGGER_RECORDER,
 };
 
 use sol_primitives::Error;

--- a/crates/assertion-executor/src/inspectors/trigger_recorder.rs
+++ b/crates/assertion-executor/src/inspectors/trigger_recorder.rs
@@ -80,7 +80,7 @@ pub enum RecordError {
 
 impl TriggerRecorder {
     /// Records a trigger call made to the trigger recorder address.
-    fn record_trigger(&mut self, input_bytes: &[u8]) -> Result<Bytes, RecordError> {
+    pub fn record_trigger(&mut self, input_bytes: &[u8]) -> Result<Bytes, RecordError> {
         match input_bytes
             .get(0..4)
             .unwrap_or_default()

--- a/crates/assertion-executor/src/store/assertion_contract_extractor.rs
+++ b/crates/assertion-executor/src/store/assertion_contract_extractor.rs
@@ -98,7 +98,13 @@ pub fn extract_assertion_contract(
 
     let env = evm_env(config.chain_id, config.spec_id, block_env.clone());
 
-    #[cfg(feature = "optimism")]
+    #[cfg(feature = "linea")]
+    let (mut evm, tx_env) = {
+        let evm = crate::evm::linea::build_linea_evm(&mut db, &env, NoOpInspector);
+        (evm, tx_env)
+    };
+
+    #[cfg(all(feature = "optimism", not(feature = "linea")))]
     let (mut evm, tx_env) = {
         use op_revm::OpTransaction;
 
@@ -106,7 +112,7 @@ pub fn extract_assertion_contract(
         (evm, OpTransaction::new(tx_env))
     };
 
-    #[cfg(not(feature = "optimism"))]
+    #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
     let (mut evm, tx_env) = {
         let evm = crate::evm::build_evm::build_eth_evm(&mut db, &env, NoOpInspector);
         (evm, tx_env)
@@ -149,7 +155,13 @@ pub fn extract_assertion_contract(
 
     // Set up and execute the call
     let mut trigger_recorder = TriggerRecorder::default();
-    #[cfg(feature = "optimism")]
+    #[cfg(feature = "linea")]
+    let (mut evm, tx_env) = {
+        let evm = crate::evm::linea::build_linea_evm(&mut db, &env, &mut trigger_recorder);
+        (evm, tx_env)
+    };
+
+    #[cfg(all(feature = "optimism", not(feature = "linea")))]
     let (mut evm, tx_env) = {
         use op_revm::OpTransaction;
 
@@ -157,7 +169,7 @@ pub fn extract_assertion_contract(
         (evm, OpTransaction::new(tx_env))
     };
 
-    #[cfg(not(feature = "optimism"))]
+    #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
     let (mut evm, tx_env) = {
         let evm = crate::evm::build_evm::build_eth_evm(&mut db, &env, &mut trigger_recorder);
         (evm, tx_env)

--- a/crates/assertion-executor/src/store/assertion_contract_extractor.rs
+++ b/crates/assertion-executor/src/store/assertion_contract_extractor.rs
@@ -98,25 +98,8 @@ pub fn extract_assertion_contract(
 
     let env = evm_env(config.chain_id, config.spec_id, block_env.clone());
 
-    #[cfg(feature = "linea")]
-    let (mut evm, tx_env) = {
-        let evm = crate::evm::linea::build_linea_evm(&mut db, &env, NoOpInspector);
-        (evm, tx_env)
-    };
-
-    #[cfg(all(feature = "optimism", not(feature = "linea")))]
-    let (mut evm, tx_env) = {
-        use op_revm::OpTransaction;
-
-        let evm = crate::evm::build_evm::build_optimism_evm(&mut db, &env, NoOpInspector);
-        (evm, OpTransaction::new(tx_env))
-    };
-
-    #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
-    let (mut evm, tx_env) = {
-        let evm = crate::evm::build_evm::build_eth_evm(&mut db, &env, NoOpInspector);
-        (evm, tx_env)
-    };
+    let mut evm = crate::build_evm_by_features!(&mut db, &env, NoOpInspector);
+    let tx_env = crate::wrap_tx_env_for_optimism!(tx_env);
 
     let result_and_state = evm
         .transact(tx_env)
@@ -155,25 +138,8 @@ pub fn extract_assertion_contract(
 
     // Set up and execute the call
     let mut trigger_recorder = TriggerRecorder::default();
-    #[cfg(feature = "linea")]
-    let (mut evm, tx_env) = {
-        let evm = crate::evm::linea::build_linea_evm(&mut db, &env, &mut trigger_recorder);
-        (evm, tx_env)
-    };
-
-    #[cfg(all(feature = "optimism", not(feature = "linea")))]
-    let (mut evm, tx_env) = {
-        use op_revm::OpTransaction;
-
-        let evm = crate::evm::build_evm::build_optimism_evm(&mut db, &env, &mut trigger_recorder);
-        (evm, OpTransaction::new(tx_env))
-    };
-
-    #[cfg(all(not(feature = "optimism"), not(feature = "linea")))]
-    let (mut evm, tx_env) = {
-        let evm = crate::evm::build_evm::build_eth_evm(&mut db, &env, &mut trigger_recorder);
-        (evm, tx_env)
-    };
+    let mut evm = crate::build_evm_by_features!(&mut db, &env, &mut trigger_recorder);
+    let tx_env = crate::wrap_tx_env_for_optimism!(tx_env);
 
     let trigger_call_result = evm
         .inspect_with_tx(tx_env)

--- a/crates/assertion-executor/tests/common/mod.rs
+++ b/crates/assertion-executor/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod harness;
 pub mod test_ctx;
 pub mod tx_utils;

--- a/crates/assertion-executor/tests/indexer_int_tests.rs
+++ b/crates/assertion-executor/tests/indexer_int_tests.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 mod common;
 
 #[cfg(test)]

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -13,7 +13,7 @@ dashmap = { workspace = true }
 revm = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-assertion-executor = { workspace = true, features = ["test", "linea"],  default-features = false }
+assertion-executor = { workspace = true, default-features = false, features = ["test", "linea"] }
 rust-tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -13,7 +13,7 @@ dashmap = { workspace = true }
 revm = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-assertion-executor = { workspace = true, features = ["test"] }
+assertion-executor = { workspace = true, features = ["test", "linea"] }
 rust-tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -13,7 +13,7 @@ dashmap = { workspace = true }
 revm = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-assertion-executor = { workspace = true, features = ["test", "linea"] }
+assertion-executor = { workspace = true, features = ["test", "linea"],  default-features = false }
 rust-tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/sidecar/src/engine/transactions_results.rs
+++ b/crates/sidecar/src/engine/transactions_results.rs
@@ -162,7 +162,7 @@ mod tests {
             let result = if i % 2 == 0 {
                 create_test_result_success()
             } else {
-                create_test_result_error(&format!("error {}", i))
+                create_test_result_error(&format!("error {i}"))
             };
             results.add_transaction_result(tx_hash, result);
         }
@@ -283,7 +283,7 @@ mod tests {
         for i in 1..=10 {
             let tx_hash = create_test_tx_hash(i);
             tx_hashes.push(tx_hash);
-            let result = create_test_result_error(&format!("error {}", i));
+            let result = create_test_result_error(&format!("error {i}"));
             results.add_transaction_result(tx_hash, result);
         }
 


### PR DESCRIPTION
- Adds the `linea` feature to assex and sidecar
- Unslopifies evm creation, we now have macros to conditionally create evms/txenvs based on the features selected
- Add compiler error for selecting multiple evms at once
- Adds CI step for linea
- Depends on https://github.com/phylaxsystems/credible-sdk/pull/72