### PR TITLE
fix: transaction_to is optional in contract creations

### DIFF
--- a/crates/sidecar/src/transport/http/server.rs
+++ b/crates/sidecar/src/transport/http/server.rs
@@ -52,7 +52,8 @@ pub struct TransactionEnv {
     pub caller: String,
     pub gas_limit: u64,
     pub gas_price: String,
-    pub transact_to: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transact_to: Option<String>,
     pub value: String,
     pub data: String,
     pub nonce: u64,


### PR DESCRIPTION
According to the Ethereum json rpc spec `transact_to` is optional upon contract creation. We should follow the spec to avoid misbehaviors and make it easier for the plugin to convert the transaction 