### PR TITLE
feat(sidecar): Flush cache upon BlockEnv if cache is out of sync

### DIFF
--- a/crates/sidecar/src/engine/queue.rs
+++ b/crates/sidecar/src/engine/queue.rs
@@ -25,6 +25,7 @@
 //! Reorg events are signals from the driver to the engine that it should discard the last
 //! executed transaction.
 
+use alloy::primitives::TxHash;
 use crossbeam::channel::{
     Receiver,
     Sender,
@@ -36,6 +37,13 @@ use revm::{
     },
     primitives::B256,
 };
+use serde::{
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
+};
+use serde_json::Value;
 
 /// Represents a transaction to be processed by the sidecar engine.
 ///
@@ -48,6 +56,146 @@ use revm::{
 pub struct QueueTransaction {
     pub tx_hash: B256,
     pub tx_env: TxEnv,
+}
+
+/// `QueueBlockEnv` encapsulates block environment data, the hash of the last transaction in the
+/// queue (if any), and the total number of transactions in the queue.
+///
+/// # Fields
+///
+/// * `block_env` - A `BlockEnv` struct that contains the flattened block environment details required for the queue.
+/// * `last_tx_hash` - An `Option` containing the hash of the last transaction in the queue, or `None` if no transactions exist.
+/// * `n_transactions` - A `u64` value indicating the total number of transactions queued.
+#[derive(Clone, Debug, Default)]
+pub struct QueueBlockEnv {
+    pub block_env: BlockEnv,
+    pub last_tx_hash: Option<TxHash>,
+    pub n_transactions: u64,
+}
+
+// Implementing custo (de)serialization for QueueBlockEnv so we can add new fields without breaking
+// backwards compatibility. We cannot use `#[serde(flatten)]` because it does not support custom
+// fields (https://github.com/serde-rs/serde/issues/1183) and it breaks the custom deserialization
+// for `u128`.
+
+impl<'de> Deserialize<'de> for QueueBlockEnv {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        // Check if this looks like the new format (has our additional fields)
+        if let Value::Object(ref map) = value
+            && (map.contains_key("last_tx_hash") || map.contains_key("n_transactions"))
+        {
+            // New format with additional fields - deserialize them manually
+            let last_tx_hash = match map.get("last_tx_hash") {
+                Some(Value::Null) | None => None, // Handle explicit null and missing fields
+                Some(Value::String(s)) if s.is_empty() => None, // Handle empty string
+                Some(v) => {
+                    Some(serde_json::from_value(v.clone()).map_err(serde::de::Error::custom)?)
+                }
+            };
+
+            let n_transactions = match map.get("n_transactions") {
+                Some(Value::Null) | None => 0, // Treat null as default value and missing fields as 0
+                Some(v) => serde_json::from_value(v.clone()).map_err(serde::de::Error::custom)?,
+            };
+
+            // Validate sequencer requirements:
+            // N > 0 + must contain last tx hash
+            // N = 0, must contain txhash = [empty, "", null] or missing
+            match n_transactions {
+                0 => {
+                    // When n_transactions is 0, last_tx_hash must be None, empty string, null, or missing
+                    if last_tx_hash.is_some() {
+                        return Err(serde::de::Error::custom(
+                            "When n_transactions is 0, last_tx_hash must be null, empty, or missing",
+                        ));
+                    }
+                }
+                _ => {
+                    // When n_transactions > 0, last_tx_hash must be present and valid
+                    if last_tx_hash.is_none() {
+                        return Err(serde::de::Error::custom(
+                            "When n_transactions > 0, last_tx_hash must be provided and non-empty",
+                        ));
+                    }
+                }
+            }
+            // Create a value without our custom fields for BlockEnv deserialization
+            let mut block_env_map = map.clone();
+            block_env_map.remove("last_tx_hash");
+            block_env_map.remove("n_transactions");
+
+            let block_env = serde_json::from_value(Value::Object(block_env_map))
+                .map_err(serde::de::Error::custom)?;
+
+            return Ok(QueueBlockEnv {
+                block_env,
+                last_tx_hash,
+                n_transactions,
+            });
+        }
+
+        // Old format - just deserialize as BlockEnv
+        let block_env = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+
+        Ok(QueueBlockEnv {
+            block_env,
+            last_tx_hash: None,
+            n_transactions: 0,
+        })
+    }
+}
+
+impl Serialize for QueueBlockEnv {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        // First, serialize the BlockEnv to get all its fields
+        let block_env_value =
+            serde_json::to_value(&self.block_env).map_err(serde::ser::Error::custom)?;
+
+        // Count the fields we need to serialize
+        let mut field_count = 0;
+        if let Value::Object(ref map) = block_env_value {
+            field_count += map.len();
+        }
+
+        // Add our additional fields if they have non-default values
+        if self.last_tx_hash.is_some() {
+            field_count += 1;
+        }
+        if self.n_transactions != 0 {
+            field_count += 1;
+        }
+
+        // Create a map serializer
+        let mut map = serializer.serialize_map(Some(field_count))?;
+
+        // Serialize all BlockEnv fields
+        if let Value::Object(block_env_map) = block_env_value {
+            for (key, value) in block_env_map {
+                map.serialize_entry(&key, &value)?;
+            }
+        }
+
+        // Serialize our additional fields only if they have non-default values
+        if self.last_tx_hash.is_some() {
+            map.serialize_entry("last_tx_hash", &self.last_tx_hash)?;
+        }
+
+        if self.n_transactions != 0 {
+            map.serialize_entry("n_transactions", &self.n_transactions)?;
+        }
+
+        map.end()
+    }
 }
 
 /// Contains the two possible types that can be sent in the transaction queue.
@@ -64,7 +212,7 @@ pub struct QueueTransaction {
 /// and should only process it as a valid event if the hashes match.
 #[derive(Debug)]
 pub enum TxQueueContents {
-    Block(BlockEnv, tracing::Span),
+    Block(QueueBlockEnv, tracing::Span),
     Tx(QueueTransaction, tracing::Span),
     Reorg(B256, tracing::Span),
 }

--- a/crates/sidecar/src/transactions_state.rs
+++ b/crates/sidecar/src/transactions_state.rs
@@ -120,6 +120,7 @@ mod tests {
     #![allow(clippy::cast_sign_loss)]
     use super::*;
     use crate::engine::queue::{
+        QueueBlockEnv,
         QueueTransaction,
         TxQueueContents,
     };
@@ -129,12 +130,9 @@ mod tests {
         TxEnv,
     };
     use revm::{
-        context::{
-            BlockEnv,
-            result::{
-                Output,
-                SuccessReason,
-            },
+        context::result::{
+            Output,
+            SuccessReason,
         },
         primitives::alloy_primitives::B256,
     };
@@ -187,7 +185,7 @@ mod tests {
 
     /// Helper function to create a test `TxQueueContents` with block
     fn create_test_block_queue_contents() -> TxQueueContents {
-        TxQueueContents::Block(BlockEnv::default(), Span::current())
+        TxQueueContents::Block(QueueBlockEnv::default(), Span::current())
     }
 
     #[test]

--- a/crates/sidecar/src/transport/README.md
+++ b/crates/sidecar/src/transport/README.md
@@ -69,24 +69,26 @@ Marks the start of a new block and end of the previous. Sends block environment 
   "jsonrpc": "2.0",
   "method": "sendBlockEnv",
   "params": {
-    "blockEnv": {
-      "number": 12345,
-      "beneficiary": "0x742d35Cc6634C0532925a3b8D23b7E07e3E23eF4",
-      "timestamp": 1692816000,
-      "gas_limit": 30000000,
-      "basefee": 10000000,
-      "difficulty": "0x0",
-      "prevrandao": "0x1234567890abcdef...",
-      "blob_excess_gas_and_price": {
-        "excess_blob_gas": 1000,
-        "blob_gasprice": 2000
-      }
-    }
+    "number": 12345,
+    "beneficiary": "0x742d35Cc6634C0532925a3b8D23b7E07e3E23eF4",
+    "timestamp": 1692816000,
+    "gas_limit": 30000000,
+    "basefee": 10000000,
+    "difficulty": "0x0",
+    "prevrandao": "0x1234567890abcdef...",
+    "blob_excess_gas_and_price": {
+      "excess_blob_gas": 1000,
+      "blob_gasprice": 2000
+    },
+    "n_transactions": 100,
+    "last_tx_hash": "0x1234567890abcdef..."
   }
 }
 ```
 
 The field `blob_excess_gas_and_price` is only required for specifications Cancun or later.
+If the `n_transactions` is 0, the `last_tx_hash` must be null (or omitted). If the `n_transactions` is > 0,
+the `last_tx_hash` must be present.
 
 **Response:**
 

--- a/crates/sidecar/src/transport/http/tracing_middleware.rs
+++ b/crates/sidecar/src/transport/http/tracing_middleware.rs
@@ -43,7 +43,7 @@ pub async fn tracing_middleware(
 pub fn trace_tx_queue_contents(block_context: &BlockContext, tx_queue_contents: &TxQueueContents) {
     match tx_queue_contents {
         // If we receive a block, update the block context
-        TxQueueContents::Block(block, _) => block_context.update(block),
+        TxQueueContents::Block(block, _) => block_context.update(&block.block_env),
         // If we receive a tx, add the tx hash to the current span
         TxQueueContents::Tx(tx, span) => {
             span.record("tx.hash", tx.tx_hash.to_string());


### PR DESCRIPTION
- Extend the blockEnv message to include the number of transactions and the last tx hash of the block
- Flush the cache if the number of transactions does not match the number of transactions process or if the last tx hash does not correspond with the last tx hash
- Adapt the integration tests to send the new data correctly, so the tests pass