### PR TITLE
feat: empty block processing in `test_core_engine_functionality`

### DIFF
--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -714,6 +714,9 @@ mod tests {
 
     #[crate::utils::engine_test(all)]
     async fn test_core_engine_functionality(mut instance: crate::utils::LocalInstance) {
+        // Send an empty block to verify we can advance the chain with empty blocks
+        instance.new_block().await.unwrap();
+
         // Send and verify a reverting CREATE transaction
         let tx_hash = instance.send_reverting_create_tx().await.unwrap();
 

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -493,6 +493,14 @@ impl<T: TestTransport> LocalInstance<T> {
 
         Ok(())
     }
+
+    /// Advance the chain by 1 block by sending a new `BlockEnv` to the core engine.
+    pub async fn new_block(&mut self) -> Result<(), String> {
+        self.transport.new_block(self.block_number).await?;
+        self.block_number += 1;
+
+        Ok(())
+    }
 }
 
 impl<T: TestTransport> Drop for LocalInstance<T> {


### PR DESCRIPTION
- Sends an empty block in `test_core_engine_functionality` to test we can advance the chain on empty blocks