### PR TITLE
feat(sidecar): proper reorg test, getTransaction results

### DIFF
--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -892,6 +892,8 @@ mod tests {
 
     #[crate::utils::engine_test(all)]
     async fn test_core_engine_reorg(mut instance: crate::utils::LocalInstance) {
+        // 1. run tx + reorg
+
         // Send and verify a successful CREATE transaction
         let tx_hash = instance
             .send_successful_create_tx(uint!(0_U256), Bytes::new())
@@ -906,6 +908,58 @@ mod tests {
 
         // Send reorg and unwrap on the result, verifying if the core engine
         // processed tx or exited with error
+        instance.send_reorg(tx_hash).await.unwrap();
+
+        // 2. tx + reorg + tx
+
+        // Send and verify a successful CREATE transaction
+        let tx_hash = instance
+            .send_successful_create_tx(uint!(0_U256), Bytes::new())
+            .await
+            .unwrap();
+
+        // Verify transaction was successful
+        assert!(
+            instance.is_transaction_successful(&tx_hash).unwrap(),
+            "Transaction should execute successfully and pass assertions"
+        );
+
+        // Send reorg and unwrap on the result, verifying if the core engine
+        // processed tx or exited with error
+        instance.send_reorg(tx_hash).await.unwrap();
+
+        let tx_hash = instance
+            .send_successful_create_tx(uint!(0_U256), Bytes::new())
+            .await
+            .unwrap();
+
+        assert!(
+            instance.is_transaction_successful(&tx_hash).unwrap(),
+            "Transaction should execute successfully and pass assertions"
+        );
+
+        // 3. tx + tx + reorg
+
+        let tx_hash = instance
+            .send_successful_create_tx(uint!(0_U256), Bytes::new())
+            .await
+            .unwrap();
+
+        assert!(
+            instance.is_transaction_successful(&tx_hash).unwrap(),
+            "Transaction should execute successfully and pass assertions"
+        );
+
+        let tx_hash = instance
+            .send_successful_create_tx(uint!(0_U256), Bytes::new())
+            .await
+            .unwrap();
+
+        assert!(
+            instance.is_transaction_successful(&tx_hash).unwrap(),
+            "Transaction should execute successfully and pass assertions"
+        );
+
         instance.send_reorg(tx_hash).await.unwrap();
     }
 

--- a/crates/sidecar/src/utils/instance.rs
+++ b/crates/sidecar/src/utils/instance.rs
@@ -545,6 +545,13 @@ impl<T: TestTransport> LocalInstance<T> {
             return Err("Engine handle does not exist! Make sure the engine was initialized before calling fn!".to_string());
         }
 
+        // Reorg was accepted by the engine and the last executed transaction
+        // was removed from the buffer. Mirror this in our local nonce tracking
+        // so that subsequent transactions use the correct nonce again.
+        if self.current_nonce > 0 {
+            self.current_nonce -= 1;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Adds the following test cases:
- tx + reorg + tx to show we correctly are able to continue a tx after a reorg
- tx + reorg to show that it should result in an empty block
- tx + tx + reorg to show that the sidecar can handle reorg as the last event in a block 