### PR TITLE
feat(sidecar): Failing Reorg integration tests

### DIFF
--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -931,6 +931,62 @@ mod tests {
         );
     }
 
+    #[crate::utils::engine_test(all)]
+    async fn test_core_engine_reorg_before_blockenv_rejected(
+        mut instance: crate::utils::LocalInstance,
+    ) {
+        // Send reorg without any prior blockenv or transaction
+        assert!(
+            instance.send_reorg(B256::random()).await.is_err(),
+            "Reorg before any blockenv should be rejected and exit engine"
+        );
+    }
+
+    #[crate::utils::engine_test(all)]
+    async fn test_core_engine_reorg_after_blockenv_before_tx_rejected(
+        mut instance: crate::utils::LocalInstance,
+    ) {
+        // Send a blockenv with no transactions
+        instance
+            .send_block_with_txs(Vec::new())
+            .await
+            .expect("should send empty blockenv");
+
+        // Now send a reorg before any transaction in this block
+        assert!(
+            instance.send_reorg(B256::random()).await.is_err(),
+            "Reorg after blockenv but before any tx should be rejected"
+        );
+    }
+
+    #[crate::utils::engine_test(all)]
+    async fn test_core_engine_reorg_valid_then_previous_rejected(
+        mut instance: crate::utils::LocalInstance,
+    ) {
+        // Execute two successful transactions
+        let _tx1 = instance
+            .send_successful_create_tx(uint!(0_U256), Bytes::new())
+            .await
+            .expect("tx1 should be sent successfully");
+        let tx2 = instance
+            .send_successful_create_tx(uint!(0_U256), Bytes::new())
+            .await
+            .expect("tx2 should be sent successfully");
+
+        // Valid reorg for the last executed tx should succeed (engine keeps running)
+        instance
+            .send_reorg(tx2)
+            .await
+            .expect("reorg of last executed tx should succeed");
+
+        // Reorg for the previous tx (tx1) should be rejected
+        // Because the engine only keeps the last executed tx in the buffer
+        assert!(
+            instance.send_reorg(B256::random()).await.is_err(),
+            "Reorg with wrong hash should be rejected and exit engine"
+        );
+    }
+
     #[test]
     fn test_database_commit_verification() {
         use revm::primitives::address;

--- a/crates/sidecar/src/engine/mod.rs
+++ b/crates/sidecar/src/engine/mod.rs
@@ -964,7 +964,7 @@ mod tests {
         mut instance: crate::utils::LocalInstance,
     ) {
         // Execute two successful transactions
-        let _tx1 = instance
+        let tx1 = instance
             .send_successful_create_tx(uint!(0_U256), Bytes::new())
             .await
             .expect("tx1 should be sent successfully");
@@ -982,7 +982,7 @@ mod tests {
         // Reorg for the previous tx (tx1) should be rejected
         // Because the engine only keeps the last executed tx in the buffer
         assert!(
-            instance.send_reorg(B256::random()).await.is_err(),
+            instance.send_reorg(tx1).await.is_err(),
             "Reorg with wrong hash should be rejected and exit engine"
         );
     }


### PR DESCRIPTION
- Send reorg before a blockenv: rejected
- Send reorg before a transaction and after a blockenv
- Send reorg with the transaction hash which is not the previous one: rejected
- Send valid reorg twice (from the previous tx and previous tx - 1): second one rejected