### PR TITLE
feat: Improve error propagation

### DIFF
--- a/crates/assertion-da/da-server/src/api/assertion_submission.rs
+++ b/crates/assertion-da/da-server/src/api/assertion_submission.rs
@@ -95,7 +95,7 @@ pub async fn accept_bytecode_assertion(
     let signature = match signer.sign_hash(&id).await {
         Ok(sig) => sig,
         Err(err) => {
-            warn!(target: "json_rpc", method = "da_submit_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, "Failed to sign assertion");
+            warn!(target: "json_rpc", method = "da_submit_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, "Failed to sign assertion");
             return Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32604,
@@ -161,7 +161,7 @@ pub async fn accept_solidity_assertion(
     let da_submission: DaSubmission = match serde_json::from_value(json_rpc["params"][0].clone()) {
         Ok(da_submission) => da_submission,
         Err(err) => {
-            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, "Failed to parse DaSubmission payload");
+            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, "Failed to parse DaSubmission payload");
             return Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32602,
@@ -183,7 +183,7 @@ pub async fn accept_solidity_assertion(
     {
         Ok(bytecode) => bytecode,
         Err(err) => {
-            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, compiler_version = da_submission.compiler_version, contract_name = da_submission.assertion_contract_name, "Solidity compilation failed");
+            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, compiler_version = da_submission.compiler_version, contract_name = da_submission.assertion_contract_name, "Solidity compilation failed");
             return Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32603,
@@ -199,7 +199,7 @@ pub async fn accept_solidity_assertion(
     ) {
         Ok(encoded_args) => encoded_args,
         Err(err) => {
-            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, constructor_abi = da_submission.constructor_abi_signature, "Constructor args ABI encoding failed");
+            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, constructor_abi = da_submission.constructor_abi_signature, "Constructor args ABI encoding failed");
             return Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32603,
@@ -217,7 +217,7 @@ pub async fn accept_solidity_assertion(
     let prover_signature = match signer.sign_hash(&id).await {
         Ok(sig) => sig,
         Err(err) => {
-            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, "Failed to sign assertion");
+            warn!(target: "json_rpc", method = "da_submit_solidity_assertion", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, "Failed to sign assertion");
             return Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32604,
@@ -332,7 +332,7 @@ async fn process_add_assertion(
     let ser_assertion = match bincode::serialize(&stored_assertion) {
         Ok(ser) => ser,
         Err(err) => {
-            error!(target: "json_rpc", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, "Failed to serialize assertion for database storage");
+            error!(target: "json_rpc", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, "Failed to serialize assertion for database storage");
             return Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32603,
@@ -360,7 +360,7 @@ async fn process_add_assertion(
             Ok(rpc_response(json_rpc, result))
         }
         Err(err) => {
-            error!(target: "json_rpc", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, "Database operation failed for assertion storage");
+            error!(target: "json_rpc", %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, "Database operation failed for assertion storage");
             Ok(rpc_error_with_request_id(
                 json_rpc,
                 -32603,

--- a/crates/assertion-da/da-server/src/api/process_request.rs
+++ b/crates/assertion-da/da-server/src/api/process_request.rs
@@ -278,7 +278,7 @@ where
             }
         }
         Err(err) => {
-            warn!(target: "json_rpc", %method, %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = %err, duration_ms = req_start.elapsed().as_millis(), "Request failed with internal error");
+            warn!(target: "json_rpc", %method, %request_id, %client_ip, json_rpc_id = %json_rpc_id, error = ?err, duration_ms = req_start.elapsed().as_millis(), "Request failed with internal error");
         }
     }
 

--- a/crates/assertion-executor/src/error.rs
+++ b/crates/assertion-executor/src/error.rs
@@ -18,9 +18,9 @@ where
     ExtDb::Error: Debug,
 {
     #[error("Fork tx execution error: {0}")]
-    ForkTxExecutionError(#[from] ForkTxExecutionError<ExtDb>),
+    ForkTxExecutionError(#[source] ForkTxExecutionError<ExtDb>),
     #[error("Assertion execution error: {0}")]
-    AssertionExecutionError(#[from] AssertionExecutionError<Active>),
+    AssertionExecutionError(#[source] AssertionExecutionError<Active>),
 }
 
 impl<Active: DatabaseRef, ExtDb: Database> Debug for ExecutorError<Active, ExtDb>
@@ -42,9 +42,9 @@ where
     ExtDb::Error: Debug,
 {
     #[error("Evm error executing transaction: {0}")]
-    TxEvmError(#[from] EVMError<ExtDb::Error>),
+    TxEvmError(#[source] EVMError<ExtDb::Error>),
     #[error("Call tracer error: {0}")]
-    CallTracerError(#[from] CallTracerError),
+    CallTracerError(#[source] CallTracerError),
 }
 
 impl<ExtDb: Database> Debug for ForkTxExecutionError<ExtDb>
@@ -65,9 +65,9 @@ where
     Active::Error: Debug,
 {
     #[error("Assertion execution error: {0}")]
-    AssertionExecutionError(#[from] EVMError<Active::Error>),
+    AssertionExecutionError(#[source] EVMError<Active::Error>),
     #[error("Assertion store error: {0}")]
-    AssertionReadError(#[from] AssertionStoreError),
+    AssertionReadError(#[source] AssertionStoreError),
 }
 
 impl<Active: DatabaseRef> Debug for AssertionExecutionError<Active>

--- a/crates/assertion-executor/src/inspectors/precompiles/calls.rs
+++ b/crates/assertion-executor/src/inspectors/precompiles/calls.rs
@@ -19,7 +19,7 @@ use alloy_sol_types::SolType;
 #[derive(thiserror::Error, Debug)]
 pub enum GetCallInputsError {
     #[error("Failed to decode getCallInputs call: {0:?}")]
-    FailedToDecodeGetCallInputsCall(#[from] alloy_sol_types::Error),
+    FailedToDecodeGetCallInputsCall(#[source] alloy_sol_types::Error),
     #[error(
         "Expected Bytes in CallInput input. This should be restricted to only CallInput::Bytes by the call tracer."
     )]

--- a/crates/assertion-executor/src/inspectors/precompiles/console_log.rs
+++ b/crates/assertion-executor/src/inspectors/precompiles/console_log.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_sol_types::SolCall;
 
 #[derive(Debug, thiserror::Error)]
-pub struct ConsoleLogError(#[from] alloy_sol_types::Error);
+pub struct ConsoleLogError(#[source] alloy_sol_types::Error);
 
 impl std::fmt::Display for ConsoleLogError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -22,9 +22,11 @@ pub fn console_log(
     input_bytes: &Bytes,
     context: &mut PhEvmContext,
 ) -> Result<Bytes, ConsoleLogError> {
-    context
-        .console_logs
-        .push(logCall::abi_decode(input_bytes)?.message);
+    context.console_logs.push(
+        logCall::abi_decode(input_bytes)
+            .map_err(ConsoleLogError)?
+            .message,
+    );
     Ok(Bytes::default())
 }
 

--- a/crates/assertion-executor/src/inspectors/precompiles/state_changes.rs
+++ b/crates/assertion-executor/src/inspectors/precompiles/state_changes.rs
@@ -20,7 +20,7 @@ use alloy_sol_types::{
 #[derive(Debug, thiserror::Error)]
 pub enum GetStateChangesError {
     #[error("Error decoding call inputs")]
-    CallDecodeError(#[from] alloy_sol_types::Error),
+    CallDecodeError(#[source] alloy_sol_types::Error),
     #[error("Journal Missing from Context. For some reason it was not captured.")]
     JournalMissing,
     #[error("Slot not found in journal, but differences were found.")]
@@ -35,7 +35,8 @@ pub fn get_state_changes(
     input_bytes: &[u8],
     context: &PhEvmContext,
 ) -> Result<Bytes, GetStateChangesError> {
-    let event = PhEvm::getStateChangesCall::abi_decode(input_bytes)?;
+    let event = PhEvm::getStateChangesCall::abi_decode(input_bytes)
+        .map_err(GetStateChangesError::CallDecodeError)?;
 
     let differences = get_differences(
         &context.logs_and_traces.call_traces.journal,

--- a/crates/assertion-executor/src/inspectors/trigger_recorder.rs
+++ b/crates/assertion-executor/src/inspectors/trigger_recorder.rs
@@ -73,7 +73,7 @@ pub struct TriggerRecorder {
 #[derive(thiserror::Error, Debug)]
 pub enum RecordError {
     #[error("Failed to decode call inputs")]
-    CallDecodeError(#[from] alloy_sol_types::Error),
+    CallDecodeError(#[source] alloy_sol_types::Error),
     #[error("Fn selector not found")]
     FnSelectorNotFound,
 }
@@ -89,13 +89,15 @@ impl TriggerRecorder {
         {
             ITriggerRecorder::registerCallTrigger_0Call::SELECTOR => {
                 let fn_selector =
-                    ITriggerRecorder::registerCallTrigger_0Call::abi_decode(input_bytes)?
+                    ITriggerRecorder::registerCallTrigger_0Call::abi_decode(input_bytes)
+                        .map_err(RecordError::CallDecodeError)?
                         .fnSelector;
                 self.add_trigger(TriggerType::AllCalls, fn_selector);
             }
 
             ITriggerRecorder::registerCallTrigger_1Call::SELECTOR => {
-                let call = ITriggerRecorder::registerCallTrigger_1Call::abi_decode(input_bytes)?;
+                let call = ITriggerRecorder::registerCallTrigger_1Call::abi_decode(input_bytes)
+                    .map_err(RecordError::CallDecodeError)?;
                 self.add_trigger(
                     TriggerType::Call {
                         trigger_selector: call.triggerSelector,
@@ -106,14 +108,16 @@ impl TriggerRecorder {
 
             ITriggerRecorder::registerStorageChangeTrigger_0Call::SELECTOR => {
                 let fn_selector =
-                    ITriggerRecorder::registerStorageChangeTrigger_0Call::abi_decode(input_bytes)?
+                    ITriggerRecorder::registerStorageChangeTrigger_0Call::abi_decode(input_bytes)
+                        .map_err(RecordError::CallDecodeError)?
                         .fnSelector;
                 self.add_trigger(TriggerType::AllStorageChanges, fn_selector);
             }
 
             ITriggerRecorder::registerStorageChangeTrigger_1Call::SELECTOR => {
                 let call =
-                    ITriggerRecorder::registerStorageChangeTrigger_1Call::abi_decode(input_bytes)?;
+                    ITriggerRecorder::registerStorageChangeTrigger_1Call::abi_decode(input_bytes)
+                        .map_err(RecordError::CallDecodeError)?;
                 self.add_trigger(
                     TriggerType::StorageChange {
                         trigger_slot: call.slot,
@@ -124,7 +128,8 @@ impl TriggerRecorder {
 
             ITriggerRecorder::registerBalanceChangeTriggerCall::SELECTOR => {
                 let fn_selector =
-                    ITriggerRecorder::registerBalanceChangeTriggerCall::abi_decode(input_bytes)?
+                    ITriggerRecorder::registerBalanceChangeTriggerCall::abi_decode(input_bytes)
+                        .map_err(RecordError::CallDecodeError)?
                         .fnSelector;
                 self.add_trigger(TriggerType::BalanceChange, fn_selector);
             }

--- a/crates/assertion-executor/src/lib.rs
+++ b/crates/assertion-executor/src/lib.rs
@@ -8,7 +8,10 @@
 #![allow(clippy::unreadable_literal)]
 
 mod error;
-pub use error::ExecutorError;
+pub use error::{
+    ExecutorError,
+    ForkTxExecutionError,
+};
 
 mod executor;
 pub use executor::{

--- a/crates/assertion-executor/src/utils/reorg_utils.rs
+++ b/crates/assertion-executor/src/utils/reorg_utils.rs
@@ -19,7 +19,7 @@ pub enum CheckIfReorgedError {
     #[error("Parent block not found")]
     ParentBlockNotFound,
     #[error("TransportError: {0}")]
-    TransportError(#[from] TransportError),
+    TransportError(#[source] TransportError),
 }
 
 /// Checks if the new block is part of the same chain as the last indexed block.
@@ -41,7 +41,8 @@ pub async fn check_if_reorged(
     loop {
         let cursor = provider
             .get_block_by_hash(cursor_hash)
-            .await?
+            .await
+            .map_err(CheckIfReorgedError::TransportError)?
             .ok_or(CheckIfReorgedError::ParentBlockNotFound)?;
 
         let cursor_header = cursor.header();

--- a/crates/int-test-utils/src/deploy_contracts.rs
+++ b/crates/int-test-utils/src/deploy_contracts.rs
@@ -21,7 +21,7 @@ pub enum DeployContractsError {
     #[error("Command execution failed. Exit Status: {0}, Error: {1}")]
     CommandError(ExitStatus, String),
     #[error("IO error: {0}")]
-    IoError(#[from] io::Error),
+    IoError(#[source] io::Error),
 }
 
 pub fn get_anvil_deployer(anvil_instance: &AnvilInstance) -> SigningKey {
@@ -57,7 +57,7 @@ pub fn deploy_create_factory(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let output = cmd.output()?;
+    let output = cmd.output().map_err(DeployContractsError::IoError)?;
     if !output.status.success() {
         return Err(DeployContractsError::CommandError(
             output.status,
@@ -129,7 +129,7 @@ pub fn deploy_contracts(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let output = cmd.output()?;
+    let output = cmd.output().map_err(DeployContractsError::IoError)?;
 
     // Check if the script executed successfully
     if output.status.success() {

--- a/crates/pcl/core/src/assertion_da.rs
+++ b/crates/pcl/core/src/assertion_da.rs
@@ -232,33 +232,29 @@ impl DaStoreArgs {
             Ok(res) => Ok(res),
             Err(err) => {
                 match &err {
-                    DaClientError::ReqwestError(reqwest_err) => {
+                    DaClientError::Reqwest(reqwest_err)
+                    | DaClientError::ReqwestResponse(reqwest_err)
+                    | DaClientError::Build(reqwest_err) => {
                         if let Some(status) = reqwest_err.status() {
                             Self::handle_http_error(status.as_u16(), spinner)?;
-                            Err(err.into())
-                        } else {
-                            Err(err.into())
                         }
                     }
-                    DaClientError::UrlParseError(_) => {
+                    DaClientError::UrlParse(_) => {
                         spinner.finish_with_message("❌ Invalid DA server URL");
-                        Err(err.into())
                     }
                     DaClientError::JsonError(_) => {
                         spinner.finish_with_message("❌ Failed to parse server response");
-                        Err(err.into())
                     }
                     DaClientError::JsonRpcError { code, message } => {
                         spinner.finish_with_message(format!(
                             "❌ Server error (code {code}): {message}"
                         ));
-                        Err(err.into())
                     }
                     DaClientError::InvalidResponse(msg) => {
                         spinner.finish_with_message(format!("❌ Invalid server response: {msg}"));
-                        Err(err.into())
                     }
                 }
+                Err(DaSubmitError::DaClientError(err))
             }
         }
     }

--- a/crates/pcl/core/src/error.rs
+++ b/crates/pcl/core/src/error.rs
@@ -8,16 +8,16 @@ use thiserror::Error;
 pub enum DaSubmitError {
     /// Error when HTTP request to the DA layer fails
     #[error("Da Submission Error: {0}")]
-    DaClientError(#[from] DaClientError),
+    DaClientError(#[source] DaClientError),
     /// Error during the build process of the assertion
     #[error("There was an error with the solidity file")]
-    PhoundryError(#[from] Box<PhoundryError>),
+    PhoundryError(#[source] Box<PhoundryError>),
     /// Failed to parse bytecode as hex
     #[error("Failed to parse bytecode as hex")]
     ParseError,
     /// From Hex Error
     #[error("From Hex Error: {0}")]
-    FromHexError(#[from] alloy_primitives::hex::FromHexError),
+    FromHexError(#[source] alloy_primitives::hex::FromHexError),
     /// HTTP Error with status code
     #[error("HTTP Error: {0}")]
     HttpError(u16),
@@ -43,7 +43,7 @@ pub enum DappSubmitError {
 
     /// Error during project selection process
     #[error("Project selection failed: {0}")]
-    ProjectSelectionFailed(#[from] inquire::InquireError),
+    ProjectSelectionFailed(#[source] inquire::InquireError),
 
     /// Error when no projects are found for the authenticated user
     #[error(
@@ -51,9 +51,21 @@ pub enum DappSubmitError {
     )]
     NoProjectsFound,
 
-    /// Error when connection to the dApp API fails
-    #[error("Failed to connect to the dApp API")]
-    ApiConnectionError(#[from] ReqwestError),
+    /// Error when sending a submission to the dApp API fails
+    #[error("Failed to send submission to the dApp API")]
+    SendSubmissionApi(#[source] ReqwestError),
+
+    /// Error while getting a submission response from the dApp API
+    #[error("Failed to read a submission response from the dApp API")]
+    SendSubmissionApiResponse(#[source] ReqwestError),
+
+    /// Error when sending a get user project to the dApp API fails
+    #[error("Failed to send a get user projects to the dApp API")]
+    GetUserProjectsApi(#[source] ReqwestError),
+
+    /// Error while getting a user project response from the dApp API
+    #[error("Failed to read a user project response from the dApp API")]
+    GetUserProjectsApiResponse(#[source] ReqwestError),
 
     /// Error when the submission is rejected by the dApp
     #[error("Submission failed: {0}")]
@@ -81,11 +93,11 @@ pub enum ConfigError {
 
     /// Error when deserializing the config file fails
     #[error("Failed to parse config file: {0}")]
-    ParseError(#[from] toml::de::Error),
+    ParseError(#[source] toml::de::Error),
 
     /// Error when serializing the config file fails
     #[error("Failed to serialize config file: {0}")]
-    SerializeError(#[from] toml::ser::Error),
+    SerializeError(#[source] toml::ser::Error),
 
     /// Error when attempting an operation that requires authentication
     /// but no authentication token is present in the config
@@ -100,7 +112,25 @@ pub enum AuthError {
     #[error(
         "Authentication request failed. Please check your connection and try again.\nError: {0}"
     )]
-    RequestFailed(#[from] reqwest::Error),
+    AuthRequestFailed(#[source] reqwest::Error),
+
+    /// Error when HTTP request to the auth service fails
+    #[error(
+        "Invalid authentication response. Please check your connection and try again.\nError: {0}"
+    )]
+    AuthRequestInvalidResponse(#[source] reqwest::Error),
+
+    /// Error when HTTP request to the auth service fails
+    #[error(
+        "Authentication status request failed. Please check your connection and try again.\nError: {0}"
+    )]
+    StatusRequestFailed(#[source] reqwest::Error),
+
+    /// Error when HTTP request to the auth service fails
+    #[error(
+        "Invalid authentication status response. Please check your connection and try again.\nError: {0}"
+    )]
+    StatusRequestInvalidResponse(#[source] reqwest::Error),
 
     /// Error when authentication times out
     #[error(
@@ -114,7 +144,7 @@ pub enum AuthError {
 
     /// Error when config operations fail during auth
     #[error("Config error: {0}")]
-    ConfigError(#[from] ConfigError),
+    ConfigError(#[source] ConfigError),
 
     /// Error when an invalid Ethereum address is received
     #[error(

--- a/crates/pcl/core/tests/da_store_int_tests.rs
+++ b/crates/pcl/core/tests/da_store_int_tests.rs
@@ -145,9 +145,7 @@ mod tests {
         let res = test_runner.run().await;
         assert!(matches!(
             res,
-            Err(DaSubmitError::DaClientError(DaClientError::UrlParseError(
-                ..
-            )))
+            Err(DaSubmitError::DaClientError(DaClientError::UrlParse(..)))
         ));
     }
 

--- a/crates/pcl/phoundry/src/build_and_flatten.rs
+++ b/crates/pcl/phoundry/src/build_and_flatten.rs
@@ -163,7 +163,8 @@ impl BuildAndFlattenArgs {
             .ephemeral_project()
             .map_err(|e| Box::new(PhoundryError::SolcError(e)))?;
 
-        let can_path = std::fs::canonicalize(path).map_err(|e| Box::new(PhoundryError::from(e)))?;
+        let can_path = std::fs::canonicalize(path)
+            .map_err(|e| Box::new(PhoundryError::CanonicalizePathError(e)))?;
 
         // Try the new flattener first
         let flattener = Flattener::new(project.clone(), &can_path);
@@ -175,9 +176,9 @@ impl BuildAndFlattenArgs {
                     .paths
                     .with_language::<SolcLanguage>()
                     .flatten(path)
-                    .map_err(|e| Box::new(PhoundryError::from(e)))
+                    .map_err(|e| Box::new(PhoundryError::SolcError(e)))
             }
-            Err(FlattenerError::Other(err)) => Err(Box::new(PhoundryError::from(err))),
+            Err(FlattenerError::Other(err)) => Err(Box::new(PhoundryError::SolcError(err))),
         }?;
 
         Ok(flattened_source)

--- a/crates/pcl/phoundry/src/error.rs
+++ b/crates/pcl/phoundry/src/error.rs
@@ -19,7 +19,7 @@ pub enum PhoundryError {
     #[error("forge is not installed or not available in PATH")]
     ForgeNotInstalled,
     #[error("forge command failed")]
-    ForgeCommandFailed(#[from] color_eyre::Report),
+    ForgeCommandFailed(#[source] color_eyre::Report),
     #[error("invalid forge output: {0}")]
     InvalidForgeOutput(&'static str),
     #[error("invalid forge command: {0}")]
@@ -27,7 +27,7 @@ pub enum PhoundryError {
     #[error("Phoundry profile {0} was not found in config {1}")]
     InvalidFoundryProfile(String, PathBuf),
     #[error("Phoundry failed to extract the config: {0}")]
-    FoundryConfigError(#[from] foundry_config::error::ExtractConfigError),
+    FoundryConfigError(#[source] foundry_config::error::ExtractConfigError),
     #[error("Contract {0} was not found in the build output")]
     ContractNotFound(String),
     #[error("Invalid path: {0:?}")]
@@ -35,11 +35,11 @@ pub enum PhoundryError {
     #[error("Directory not found: {0:?}")]
     DirectoryNotFound(PathBuf),
     #[error("Solc error: {0}")]
-    SolcError(#[from] SolcError),
+    SolcError(#[source] SolcError),
     #[error("Failed to canonicalize path: {0:?}")]
-    CanonicalizePathError(#[from] std::io::Error),
+    CanonicalizePathError(#[source] std::io::Error),
     #[error("Flattener error: {0}")]
-    FlattenerError(#[from] FlattenerError),
+    FlattenerError(#[source] FlattenerError),
     #[error("No source files found in specified build paths.")]
     NoSourceFilesFound,
     #[error("Compilation failed:\n{0}")]
@@ -54,7 +54,7 @@ impl From<ExtractConfigError> for Box<PhoundryError> {
 
 impl From<std::io::Error> for Box<PhoundryError> {
     fn from(error: std::io::Error) -> Self {
-        Box::new(PhoundryError::from(error))
+        Box::new(PhoundryError::CanonicalizePathError(error))
     }
 }
 

--- a/crates/sidecar/src/cache/mod.rs
+++ b/crates/sidecar/src/cache/mod.rs
@@ -158,7 +158,7 @@ impl DatabaseRef for Cache {
                         target = "cache::basic_ref",
                         name = %source.name(),
                         address = %address,
-                        error = %e,
+                        error = ?e,
                         "Failed to fetch account info from cache source");
                 }
                 res.ok()
@@ -175,7 +175,7 @@ impl DatabaseRef for Cache {
                         target = "cache::block_hash_ref",
                         name = %source.name(),
                         number = number,
-                        error = %e,
+                        error = ?e,
                         "Failed to fetch block hash from cache source");
                 }
                 res.ok()
@@ -192,7 +192,7 @@ impl DatabaseRef for Cache {
                         target = "cache::code_by_hash_ref",
                         name = %source.name(),
                         code_hash = %code_hash,
-                        error = %e,
+                        error = ?e,
                         "Failed to fetch code by hash from cache source");
                 }
                 res.ok()
@@ -214,7 +214,7 @@ impl DatabaseRef for Cache {
                         name = %source.name(),
                         address = %address,
                         index = %index,
-                        error = %e,
+                        error = ?e,
                         "Failed to fetch the storage from cache source");
                 }
                 res.ok()

--- a/crates/sidecar/src/cache/sources/besu_client.rs
+++ b/crates/sidecar/src/cache/sources/besu_client.rs
@@ -128,7 +128,7 @@ impl BesuClient {
                     backoff = Duration::from_secs(0);
                 }
                 Err(e) => {
-                    error!(error = %e.to_string(), "Sync error, retrying in {:?}", backoff);
+                    error!(error = ?e, "Sync error, retrying in {:?}", backoff);
                     backoff = ((backoff + Duration::from_secs(1)) * 2).min(Self::MAX_BACKOFF);
                 }
             }

--- a/crates/sidecar/src/config.rs
+++ b/crates/sidecar/src/config.rs
@@ -51,7 +51,7 @@ pub fn init_assertion_store(args: &SidecarArgs) -> Result<AssertionStore, Assert
         db_config = db_config.flush_every_ms(Some(flush_ms));
     }
 
-    let db = db_config.open()?;
+    let db = db_config.open().map_err(AssertionStoreError::SledError)?;
 
     info!(
         db_path = ?args.credible.assertion_store_db_path,

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -143,27 +143,27 @@ async fn main() -> anyhow::Result<()> {
             result = engine.run() => {
                 if let Err(e) = result {
                     if ErrorRecoverability::from(&e).is_recoverable() {
-                        tracing::error!(error = %e, "Engine exited");
+                        tracing::error!(error = ?e, "Engine exited");
                     } else {
-                        critical!(error = %e, "Engine exited");
+                        critical!(error = ?e, "Engine exited");
                     }
                 }
             }
             result = transport.run() => {
                 if let Err(e) = result {
                     if ErrorRecoverability::from(&e).is_recoverable() {
-                        tracing::error!(error = %e, "Transport exited");
+                        tracing::error!(error = ?e, "Transport exited");
                     } else {
-                        critical!(error = %e, "Transport exited");
+                        critical!(error = ?e, "Transport exited");
                     }
                 }
             }
             result = indexer::run_indexer(indexer_cfg) => {
                 if let Err(e) = result {
                     if ErrorRecoverability::from(&e).is_recoverable() {
-                        tracing::error!(error = %e, "Indexer exited");
+                        tracing::error!(error = ?e, "Indexer exited");
                     } else {
-                        critical!(error = %e, "Indexer exited");
+                        critical!(error = ?e, "Indexer exited");
                     }
                 }
             }

--- a/crates/sidecar/src/transport/grpc/mod.rs
+++ b/crates/sidecar/src/transport/grpc/mod.rs
@@ -130,7 +130,7 @@ impl Transport for GrpcTransport {
         let listener = tokio::net::TcpListener::bind(self.bind_addr)
             .await
             .map_err(|e| {
-                error!(bind_addr = %self.bind_addr, error = %e, "Failed to bind gRPC listener");
+                error!(bind_addr = %self.bind_addr, error = ?e, "Failed to bind gRPC listener");
                 GrpcTransportError::BindAddress(self.bind_addr.to_string())
             })?;
 
@@ -152,7 +152,7 @@ impl Transport for GrpcTransport {
             .serve_with_incoming_shutdown(incoming, async move { shutdown.cancelled().await })
             .await
             .map_err(|e| {
-                error!(error = %e, "gRPC server failed");
+                error!(error = ?e, "gRPC server failed");
                 GrpcTransportError::ServerError(e.to_string())
             })?;
 

--- a/crates/sidecar/src/transport/grpc/server.rs
+++ b/crates/sidecar/src/transport/grpc/server.rs
@@ -147,7 +147,7 @@ impl SidecarTransport for GrpcService {
             let queue_tx = match to_queue_tx(&t) {
                 Ok(tx) => tx,
                 Err(e) => {
-                    warn!(error = %e, "Skipping invalid transaction in gRPC batch");
+                    warn!(error = ?e, "Skipping invalid transaction in gRPC batch");
                     continue;
                 }
             };

--- a/crates/sidecar/src/transport/http/block_context.rs
+++ b/crates/sidecar/src/transport/http/block_context.rs
@@ -24,7 +24,7 @@ impl BlockContext {
                 *guard = Some(block_env.number);
             }
             Err(e) => {
-                tracing::error!(error = %e, "Failed to acquire write lock for block context");
+                tracing::error!(error = ?e, "Failed to acquire write lock for block context");
             }
         }
     }
@@ -34,7 +34,7 @@ impl BlockContext {
         match self.current_block_number.read() {
             Ok(guard) => *guard,
             Err(e) => {
-                tracing::error!(error = %e, "Failed to acquire read lock for block context");
+                tracing::error!(error = ?e, "Failed to acquire read lock for block context");
                 None
             }
         }

--- a/crates/sidecar/src/transport/http/mod.rs
+++ b/crates/sidecar/src/transport/http/mod.rs
@@ -51,7 +51,7 @@ pub enum HttpTransportError {
     #[error("Failed to bind the address: {0}")]
     BindAddress(String),
     #[error("Client error: {0}")]
-    ClientError(#[from] reqwest::Error),
+    ClientError(#[source] reqwest::Error),
 }
 
 impl From<&HttpTransportError> for ErrorRecoverability {
@@ -171,7 +171,7 @@ impl Transport for HttpTransport {
             .map_err(|e| {
                 error!(
                     bind_addr = %self.bind_addr,
-                    error = %e,
+                    error = ?e,
                     "Failed to bind HTTP transport listener"
                 );
                 HttpTransportError::BindAddress(self.bind_addr.to_string())
@@ -187,7 +187,7 @@ impl Transport for HttpTransport {
             .with_graceful_shutdown(async move { shutdown_token.cancelled().await })
             .await
             .map_err(|e| {
-                error!(error = %e, "HTTP server failed");
+                error!(error = ?e, "HTTP server failed");
                 HttpTransportError::ServerError(e.to_string())
             })?;
         Ok(())

--- a/crates/sidecar/src/transport/http/server.rs
+++ b/crates/sidecar/src/transport/http/server.rs
@@ -310,7 +310,7 @@ async fn process_request(
         Ok(tx_queue_contents) => tx_queue_contents,
         Err(e) => {
             error!(
-                error = %e,
+                error = ?e,
                 "Failed to decode transactions"
             );
             return Ok(JsonRpcResponse::invalid_request(
@@ -337,7 +337,7 @@ async fn process_request(
         state.transactions_results.add_accepted_tx(&queue_tx);
         if let Err(e) = state.tx_sender.send(queue_tx) {
             error!(
-                error = %e,
+                error = ?e,
                 "Failed to send tx queue content to queue from transport server"
             );
             return Ok(JsonRpcResponse::internal_error(

--- a/crates/sidecar/src/transport/mod.rs
+++ b/crates/sidecar/src/transport/mod.rs
@@ -119,9 +119,9 @@ use http::{
 #[derive(Debug, thiserror::Error)]
 pub enum AnyTransportError {
     #[error("HTTP transport error: {0}")]
-    Http(#[from] HttpTransportError),
+    Http(#[source] HttpTransportError),
     #[error("gRPC transport error: {0}")]
-    Grpc(#[from] GrpcTransportError),
+    Grpc(#[source] GrpcTransportError),
 }
 
 impl From<&AnyTransportError> for ErrorRecoverability {
@@ -143,8 +143,8 @@ pub enum AnyTransport {
 impl AnyTransport {
     pub async fn run(&self) -> Result<(), AnyTransportError> {
         match self {
-            AnyTransport::Http(t) => t.run().await.map_err(AnyTransportError::from),
-            AnyTransport::Grpc(t) => t.run().await.map_err(AnyTransportError::from),
+            AnyTransport::Http(t) => t.run().await.map_err(AnyTransportError::Http),
+            AnyTransport::Grpc(t) => t.run().await.map_err(AnyTransportError::Grpc),
         }
     }
 


### PR DESCRIPTION
- Change all the errors from `#[from]` to `#[source]`. This way we do not mask errors which aren't supposed to be the same. For example:
From:
```rust
        let response = client
            .post(format!(
                "{}/projects/{}/submitted-assertions",
                self.api_url, project.project_id
            ))
            .header(
                "Authorization",
                format!("Bearer {}", config.auth.as_ref().unwrap().access_token),
            )
            .header("Content-Type", "application/json")
            .json(&body)
            .send()
            .await?
            .text()
            .await?;
```
To:
```rust
        let response = client
            .post(format!(
                "{}/projects/{}/submitted-assertions",
                self.api_url, project.project_id
            ))
            .header(
                "Authorization",
                format!("Bearer {}", config.auth.as_ref().unwrap().access_token),
            )
            .header("Content-Type", "application/json")
            .json(&body)
            .send()
            .await
            .map_err(DappSubmitError::SendSubmissionApi)?;
            .text()
            .await
            .map_err(DappSubmitError::SendSubmissionApiResponse)?;
```

It is not the same to fail because of sending a response, or getting the text from it. Even tho underneath they are both `reqwest::Error`. What's more, this way, we can enforce easily one different error per occurrence. It should not be the same one request error for posting an assertion, than one from getting it.
- This PR does not address the uniqueness of the errors for all of them.
- Changed the way we log the errors. If we log them as `Display` (e.g., `error = %error`), then we get the last error name of the chain. So, let's say we have this:

```rust
#[derive(Error, Debug)]
MyMainError{
   #[error("Failed")]
    FIrst(#[source] MyFirstChainedError)
}

#[derive(Error, Debug)]
MyFirstChainedError{
   #[error("Failed")]
    Second(#[source] MySecondChainedError)
}

#[derive(Error, Debug)]
MySecondChainedError{
   #[error("Failed")]
    Third,
}
```

The log of the upper most error would be
- `error = %error` -> `First`
- `error = ?error` -> `First(Second(Third))`

Therefore, we can follow easily the error chain.