### PR TITLE
docker: add ca-certificates to image OS

### DIFF
--- a/dockerfile/Dockerfile.sidecar
+++ b/dockerfile/Dockerfile.sidecar
@@ -28,6 +28,7 @@ RUN cargo build --release --locked --bin sidecar $BUILD_FLAGS
 FROM ubuntu:24.04
 WORKDIR /usr/local/bin
 
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /sidecar/target/release/sidecar /usr/local/bin/sidecar
 
 ENTRYPOINT ["/usr/local/bin/sidecar"]


### PR DESCRIPTION
# Description

Adds `ca-certificates` in the underlying base OS.

**NOTE**:  no clue how this helped, but seems the `CryptoProvider` is only there for crypto operations, not importing any certs (we could have used webpki-roots also, but seems this is more straightforward)