### PR TITLE
fix: internal indexer restart on lagged

### DIFF
--- a/crates/assertion-da/da-client/src/lib.rs
+++ b/crates/assertion-da/da-client/src/lib.rs
@@ -7,6 +7,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use std::sync::Arc;
 
 use url::Url;
 
@@ -30,11 +31,11 @@ pub use assertion_da_core::{
 ///     let assertion_id = fixed_bytes!("044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d");
 ///     let assertion = da_client.fetch_assertion(assertion_id).await.unwrap();
 /// }         
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DaClient {
     client: Client,
     base_url: Url,
-    request_id: std::sync::atomic::AtomicU64,
+    request_id: Arc<std::sync::atomic::AtomicU64>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -92,7 +93,7 @@ impl DaClient {
         Ok(Self {
             client,
             base_url,
-            request_id: std::sync::atomic::AtomicU64::new(1),
+            request_id: std::sync::atomic::AtomicU64::new(1).into(),
         })
     }
 
@@ -116,7 +117,7 @@ impl DaClient {
         Ok(Self {
             client,
             base_url,
-            request_id: std::sync::atomic::AtomicU64::new(1),
+            request_id: std::sync::atomic::AtomicU64::new(1).into(),
         })
     }
 

--- a/crates/assertion-executor/src/store/indexer.rs
+++ b/crates/assertion-executor/src/store/indexer.rs
@@ -165,6 +165,9 @@ impl From<BlockTag> for BlockNumberOrTag {
 
 type PubSubProvider = RootProvider;
 
+/// The block range for which the indexer will get logs from.
+/// Different clients have different allowed ranges. If the sidecar errors,
+/// reduce this value to something acceptable in your case.
 const MAX_BLOCKS_PER_CALL: u64 = 50_000;
 
 #[derive(Debug, thiserror::Error)]
@@ -208,7 +211,7 @@ pub enum IndexerError {
 type IndexerResult<T = ()> = std::result::Result<T, IndexerError>;
 
 /// Configuration for the Indexer
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexerCfg {
     /// The State Oracle contract address
     pub state_oracle: Address,

--- a/crates/sidecar/src/indexer.rs
+++ b/crates/sidecar/src/indexer.rs
@@ -11,6 +11,11 @@ use assertion_executor::store::{
     IndexerCfg,
     IndexerError,
 };
+use tokio::time::{
+    Duration,
+    Instant,
+    sleep,
+};
 
 /// Runs the indexer to monitor blockchain events from the Credible Layer state oracle contract
 ///
@@ -21,17 +26,65 @@ use assertion_executor::store::{
 ///
 /// The indexer syncs to the current blockchain head before entering continuous monitoring mode.
 pub async fn run_indexer(indexer_cfg: IndexerCfg) -> Result<(), IndexerError> {
+    const RESTART_WINDOW: Duration = Duration::from_secs(5);
+    const MAX_RESTARTS_IN_WINDOW: u32 = 5;
+    const BACKOFF_STEP_MS: u64 = 200;
+
+    let mut restart_window_start: Option<Instant> = None;
+    let mut restart_count = 0u32;
+
     // First, we create an indexer and sync it to the head.
-    let indexer = Box::pin(Indexer::new_synced(indexer_cfg)).await?;
-    // We can then run the indexer and update the assertion store as new
-    // assertions come in
-    match indexer.run().await {
-        Ok(()) => Ok(()),
-        Err(IndexerError::TransportError(e)) => {
-            critical!(error = ?e, "indexer transport error");
-            Err(IndexerError::TransportError(e))
+    loop {
+        let indexer = Box::pin(Indexer::new_synced(indexer_cfg.clone())).await?;
+        // We can then run the indexer and update the assertion store as new
+        // assertions come in
+        match indexer.run().await {
+            Ok(()) => break Ok(()),
+            // `BlockStreamError`/`TransportError` happens when the indexer WS subscriptions
+            // close which can happen occasionally due to WS flakiness,
+            // we dont need to raise this error further and can try to recover internally.
+            //
+            // If that fails, we escalte this if we fail to restart 5 times in a row in 5 secs.
+            Err(IndexerError::BlockStreamError(e)) /*| Err(IndexerError::TransportError(e))*/ => {
+                let now = Instant::now();
+                let window_start = restart_window_start.unwrap_or(now);
+
+                if restart_window_start.is_none()
+                    || now.duration_since(window_start) > RESTART_WINDOW
+                {
+                    restart_window_start = Some(now);
+                    restart_count = 0;
+                }
+
+                restart_count += 1;
+
+                if restart_count > MAX_RESTARTS_IN_WINDOW {
+                    critical!(
+                        error = ?e,
+                        failures_in_window = restart_count,
+                        restarts_in_window = restart_count.saturating_sub(1),
+                        "indexer restarted too frequently; escalating block stream error",
+                    );
+                    break Err(IndexerError::BlockStreamError(e));
+                }
+
+                let backoff = Duration::from_millis(BACKOFF_STEP_MS * restart_count as u64);
+
+                tracing::warn!(
+                    error = ?e,
+                    failures_in_window = restart_count,
+                    backoff_ms = backoff.as_millis(),
+                    "indexer closed channel, restarting after backoff",
+                );
+                sleep(backoff).await;
+                continue;
+            }
+            Err(IndexerError::TransportError(e)) => {
+                critical!(error = ?e, "indexer transport error");
+                break Err(IndexerError::TransportError(e));
+            }
+            Err(e) => break Err(e),
         }
-        Err(e) => Err(e),
     }
 }
 
@@ -41,13 +94,13 @@ impl From<&IndexerError> for ErrorRecoverability {
             IndexerError::TransportError(_)
             | IndexerError::SledError(_)
             | IndexerError::DaClientError(_)
-            | IndexerError::BlockStreamError(_)
             | IndexerError::AssertionStoreError(_) => ErrorRecoverability::Unrecoverable,
             IndexerError::BincodeError(_)
             | IndexerError::EventDecodeError(_)
             | IndexerError::BlockNumberMissing
             | IndexerError::LogIndexMissing
             | IndexerError::BlockNumberExceedsU64
+            | IndexerError::BlockStreamError(_)
             | IndexerError::DaBytecodeDecodingFailed(_)
             | IndexerError::ParentBlockNotFound
             | IndexerError::BlockHashMissing


### PR DESCRIPTION
- internally restart the indexer when the connection temporarily drops
- raise the error further if we cannot resolve it after 5 times in 5 secs