### PR TITLE
fix: stall on unsynced sources

### DIFF
--- a/crates/sidecar/src/args/mod.rs
+++ b/crates/sidecar/src/args/mod.rs
@@ -158,7 +158,7 @@ pub struct HttpTransportArgs {
 }
 
 /// State sources configuration
-#[derive(Debug, Default, Clone, PartialEq, Eq, clap::Args)]
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 pub struct StateArgs {
     /// Sequencer bind address and port
     #[arg(long = "state.sequencer-url", env = "STATE_SEQUENCER_URL")]
@@ -179,6 +179,27 @@ pub struct StateArgs {
         env = "STATE_MINIMUM_STATE_DIFF"
     )]
     pub minimum_state_diff: u64,
+
+    /// Maximum time (ms) the engine will wait for a state source to report as
+    /// synced before failing a transaction.
+    #[arg(
+        long = "state.sources-sync-timeout-ms",
+        default_value = "1000",
+        env = "STATE_SOURCES_SYNC_TIMEOUT_MS"
+    )]
+    pub sources_sync_timeout_ms: u64,
+}
+
+impl Default for StateArgs {
+    fn default() -> Self {
+        Self {
+            sequencer_url: None,
+            besu_client_ws_url: None,
+            redis_url: None,
+            minimum_state_diff: 100,
+            sources_sync_timeout_ms: 100,
+        }
+    }
 }
 
 /// Main sidecar arguments that extend `TelemetryArgs` and `CredibleArgs`

--- a/crates/sidecar/src/cache/mod.rs
+++ b/crates/sidecar/src/cache/mod.rs
@@ -153,7 +153,7 @@ impl Cache {
     ///
     /// Sources are returned in priority order, with the highest priority
     /// synced source returned first.
-    fn iter_synced_sources(&self) -> impl Iterator<Item = Arc<dyn Source>> {
+    pub fn iter_synced_sources(&self) -> impl Iterator<Item = Arc<dyn Source>> {
         let instant = Instant::now();
 
         // MAX(latest BlockEnv - MINIMUM_STATE_DIFF, First block env processed)

--- a/crates/sidecar/src/main.rs
+++ b/crates/sidecar/src/main.rs
@@ -32,7 +32,10 @@ use assertion_executor::{
     db::overlay::OverlayDb,
 };
 use crossbeam::channel::unbounded;
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 
 use clap::Parser;
 use rust_tracing::trace;
@@ -142,6 +145,7 @@ async fn main() -> anyhow::Result<()> {
             assertion_executor.clone(),
             engine_state_results.clone(),
             args.credible.transaction_results_max_capacity,
+            Duration::from_millis(args.state.sources_sync_timeout_ms),
         );
 
         let indexer_cfg =

--- a/crates/sidecar/src/utils/test_drivers.rs
+++ b/crates/sidecar/src/utils/test_drivers.rs
@@ -75,6 +75,7 @@ use serde_json::json;
 use std::{
     net::SocketAddr,
     sync::Arc,
+    time::Duration,
 };
 use tonic::transport::Channel;
 use tracing::{
@@ -217,6 +218,7 @@ impl TestTransport for LocalInstanceMockDriver {
             assertion_executor,
             state_results.clone(),
             10,
+            Duration::from_millis(100),
         );
 
         // Spawn the engine task that manually processes items
@@ -411,6 +413,7 @@ impl TestTransport for LocalInstanceHttpDriver {
             assertion_executor,
             state_results.clone(),
             10,
+            Duration::from_millis(100),
         );
 
         // Spawn the engine task that manually processes items
@@ -799,6 +802,7 @@ impl TestTransport for LocalInstanceGrpcDriver {
             assertion_executor,
             state_results.clone(),
             10,
+            Duration::from_millis(100),
         );
 
         // Spawn the engine task


### PR DESCRIPTION
- Stall the sidecar if we have no synced sources
- If after 5 tries with 15ms between them we do not have anything synced we error with a recoverable error